### PR TITLE
Fix MAX_TIMERS inconsistency between main.cpp and config module

### DIFF
--- a/src/config.ixx
+++ b/src/config.ixx
@@ -14,7 +14,7 @@ export struct Config {
     bool show_sw   = true;
     bool show_tmr  = true;
     bool topmost   = false;
-    static constexpr int MAX_TIMERS = 8;
+    static constexpr int MAX_TIMERS = 3;
     int  num_timers = 1;
     std::array<int, MAX_TIMERS> timer_secs{};
     bool pos_valid = false;


### PR DESCRIPTION
Change Config::MAX_TIMERS from 8 to 3 to match the runtime limit in main.cpp, ensuring the config module cannot store more timers than the application actually supports.

Closes #2

https://claude.ai/code/session_01FtYRRxRVKFmrfTQ48A5CsT