### PR TITLE
fix: Address all 6 open bugs

### DIFF
--- a/src/config.ixx
+++ b/src/config.ixx
@@ -14,7 +14,7 @@ export struct Config {
     bool show_sw   = true;
     bool show_tmr  = true;
     bool topmost   = false;
-    static constexpr int MAX_TIMERS = 8;
+    static constexpr int MAX_TIMERS = 3;
     int  num_timers = 1;
     std::array<int, MAX_TIMERS> timer_secs{};
     bool pos_valid = false;
@@ -55,7 +55,7 @@ export bool config_read(Config& c, std::istream& f) {
         else {
             for (int i = 0; i < Config::MAX_TIMERS; ++i)
                 if (key == std::format("timer{}", i))
-                    c.timer_secs[i] = std::max(10, val);
+                    c.timer_secs[i] = std::clamp(val, 10, 86400);
         }
     }
     c.pos_valid = has_x && has_y && has_w;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,16 @@ import timer;
 using namespace std::chrono;
 using sc = steady_clock;
 
+// ─── RAII wrapper for GDI objects ────────────────────────────────────────────
+struct GdiObj {
+    HGDIOBJ h;
+    explicit GdiObj(HGDIOBJ h) : h(h) {}
+    ~GdiObj() { if (h) DeleteObject(h); }
+    GdiObj(const GdiObj&) = delete;
+    GdiObj& operator=(const GdiObj&) = delete;
+    operator HGDIOBJ() const { return h; }
+};
+
 // ─── Colors ───────────────────────────────────────────────────────────────────
 constexpr COLORREF C_BG     = RGB( 26,  26,  26);
 constexpr COLORREF C_BAR    = RGB( 35,  35,  38);
@@ -209,13 +219,12 @@ static RECT btn(HDC hdc, RECT r, bool active, const wchar_t* label, int id,
     COLORREF col = blinking      ? C_BLINK
                  : override_col  ? override_col
                  : (active       ? C_ACT : C_BTN);
-    HBRUSH br  = CreateSolidBrush(col);
-    HPEN   pn  = CreatePen(PS_NULL, 0, 0);
+    GdiObj br{CreateSolidBrush(col)};
+    GdiObj pn{CreatePen(PS_NULL, 0, 0)};
     auto*  obr = (HBRUSH)SelectObject(hdc, br);
     auto*  opn = (HPEN)  SelectObject(hdc, pn);
     RoundRect(hdc, r.left, r.top, r.right, r.bottom, 6, 6);
     SelectObject(hdc, obr); SelectObject(hdc, opn);
-    DeleteObject(br); DeleteObject(pn);
     SetBkMode(hdc, TRANSPARENT);
     SetTextColor(hdc, C_TEXT);
     DrawTextW(hdc, label, -1, &r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
@@ -224,12 +233,11 @@ static RECT btn(HDC hdc, RECT r, bool active, const wchar_t* label, int id,
 }
 
 static void divider(HDC hdc, int y, int cw) {
-    HPEN pn = CreatePen(PS_SOLID, 1, RGB(50, 50, 55));
+    GdiObj pn{CreatePen(PS_SOLID, 1, RGB(50, 50, 55))};
     auto* op = (HPEN)SelectObject(hdc, pn);
     MoveToEx(hdc, 0, y, nullptr);
     LineTo(hdc, cw, y);
     SelectObject(hdc, op);
-    DeleteObject(pn);
 }
 
 static void resize_window(HWND hwnd) {
@@ -253,15 +261,13 @@ static void paint_all(HDC hdc, int cw) {
     SetBkMode(hdc, TRANSPARENT);
 
     RECT all{0, 0, cw, 9999};
-    HBRUSH bgbr = CreateSolidBrush(C_BG);
-    FillRect(hdc, &all, bgbr);
-    DeleteObject(bgbr);
+    GdiObj bgbr{CreateSolidBrush(C_BG)};
+    FillRect(hdc, &all, (HBRUSH)bgbr.h);
 
     // ── Top bar ─────────────────────────────────────────────────────────────
     RECT bar{0, 0, cw, BAR_H};
-    HBRUSH barbr = CreateSolidBrush(C_BAR);
-    FillRect(hdc, &bar, barbr);
-    DeleteObject(barbr);
+    GdiObj barbr{CreateSolidBrush(C_BAR)};
+    FillRect(hdc, &bar, (HBRUSH)barbr.h);
 
     SelectObject(hdc, hFontSm);
     int by = (BAR_H - BTN_H) / 2;
@@ -339,9 +345,8 @@ static void paint_all(HDC hdc, int cw) {
                     fw = total > 0 ? (int)(cw * (double)(total - rem) / total) : 0;
                 }
                 RECT fr{0, y, fw, y + TMR_H};
-                HBRUSH fbr = CreateSolidBrush(fillcol);
-                FillRect(hdc, &fr, fbr);
-                DeleteObject(fbr);
+                GdiObj fbr{CreateSolidBrush(fillcol)};
+                FillRect(hdc, &fr, (HBRUSH)fbr.h);
             }
 
             int mm_cx = cw/2 - 34, ss_cx = cw/2 + 34;
@@ -460,6 +465,9 @@ static void handle(HWND hwnd, int act) {
                     fwprintf(f, L"Lap %-3zu   split %-14ls   total %ls\n",
                              n, fmt_sw(laps.back()).c_str(), fmt_sw(cum).c_str());
                     fclose(f);
+                } else {
+                    MessageBoxW(hwnd, L"Could not write lap file.\nLap data may be lost.",
+                                L"Chronos", MB_OK | MB_ICONWARNING);
                 }
             }
         }
@@ -499,7 +507,7 @@ static void handle(HWND hwnd, int act) {
             } else if (!ts.t.touched()) {
                 auto adj = [&](int ds) {
                     auto new_s = ts.dur.count() + ds;
-                    ts.dur = seconds{std::max(10LL, new_s)};
+                    ts.dur = seconds{std::clamp(new_s, 10LL, 86400LL)};
                     ts.t.reset(); ts.t.set(ts.dur);
                 };
                 if (off == A_TMR_MUP) { adj(+60); do_save = true; }
@@ -522,6 +530,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         hFontBig   = make_font(26, true);
         hFontLarge = make_font(34, true);
         hFontSm    = make_font(11, false);
+        if (!hFontBig)   hFontBig   = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+        if (!hFontLarge) hFontLarge = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+        if (!hFontSm)    hFontSm   = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         SetTimer(hwnd, 1, 100, nullptr);
         BOOL dark = TRUE;
         DwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */,
@@ -574,10 +585,17 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     }
     case WM_GETMINMAXINFO: {
         auto* m = (MINMAXINFO*)lp;
-        RECT wr, cr;
-        GetWindowRect(hwnd, &wr); GetClientRect(hwnd, &cr);
-        int nc_w = (wr.right - wr.left) - cr.right;
-        m->ptMinTrackSize.x = BAR_MIN_CLIENT_W + nc_w;
+        DWORD ws = (DWORD)GetWindowLongW(hwnd, GWL_STYLE);
+        RECT adj{0, 0, BAR_MIN_CLIENT_W, 0};
+        AdjustWindowRectEx(&adj, ws, FALSE, 0);
+        m->ptMinTrackSize.x = adj.right - adj.left;
+        int ch = BAR_H;
+        if (app.show_clk) ch += CLK_H;
+        if (app.show_sw)  ch += SW_H;
+        if (app.show_tmr) ch += (int)app.timers.size() * TMR_H;
+        RECT adj_h{0, 0, 0, ch};
+        AdjustWindowRectEx(&adj_h, ws, FALSE, 0);
+        m->ptMinTrackSize.y = adj_h.bottom - adj_h.top;
         return 0;
     }
     case WM_EXITSIZEMOVE:


### PR DESCRIPTION
## Summary\n\n- **Bug #1 (GDI leak):** Add `GdiObj` RAII wrapper to prevent GDI handle leaks in `btn()`, `divider()`, and `paint_all()`\n- **Bug #2 (MAX_TIMERS mismatch):** Align `Config::MAX_TIMERS` from 8 to 3 to match `main.cpp`\n- **Bug #3 (Silent lap file failure):** Show `MessageBox` warning when stopwatch lap file cannot be written\n- **Bug #4 (Min window height):** Enforce both minimum width and height in `WM_GETMINMAXINFO` using `AdjustWindowRectEx`\n- **Bug #5 (Font fallback):** Fall back to `DEFAULT_GUI_FONT` when `make_font()` returns `nullptr`\n- **Bug #6 (Timer upper bound):** Clamp timer duration to `[10, 86400]` seconds in both config loading and runtime adjustment\n\n## Test plan\n\n- [ ] Run app for extended session and verify GDI handle count stays stable (Task Manager > Details > GDI Objects)\n- [ ] Edit config.ini with >3 timers and verify app loads correctly with max 3\n- [ ] Make lap file path read-only and verify error dialog appears on lap recording\n- [ ] Resize window and verify it cannot be shrunk below content area\n- [ ] Remove/rename \"Segoe UI\" font and verify app still renders with fallback font\n- [ ] Repeatedly press timer up arrow and verify duration caps at 24:00:00\n\nhttps://claude.ai/code/session_01FtYRRxRVKFmrfTQ48A5CsT