### PR TITLE
Add milliseconds to stopwatch lap filename

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,9 +443,10 @@ static void handle(HWND hwnd, int act) {
         if (!app.sw.is_running()) {
             if (app.sw_lap_file.empty()) {
                 SYSTEMTIME st; GetLocalTime(&st);
-                app.sw_lap_file = std::format(L"stopwatch-{:04}{:02}{:02}-{:02}{:02}{:02}.txt",
+                app.sw_lap_file = std::format(L"stopwatch-{:04}{:02}{:02}-{:02}{:02}{:02}-{:03}.txt",
                                               st.wYear, st.wMonth, st.wDay,
-                                              st.wHour, st.wMinute, st.wSecond);
+                                              st.wHour, st.wMinute, st.wSecond,
+                                              st.wMilliseconds);
             }
             app.sw.start(now);
         } else {


### PR DESCRIPTION
## Summary\n- Appends milliseconds (`{:03}`) to the stopwatch lap filename, changing the pattern from `stopwatch-YYYYMMDD-HHMMSS.txt` to `stopwatch-YYYYMMDD-HHMMSS-mmm.txt`\n- Reduces the chance of filename collisions when multiple instances start stopwatches within the same second\n\nCloses #13\n\n## Test plan\n- [ ] Start two stopwatch instances within the same second and verify different filenames are generated\n- [ ] Verify lap data is written correctly to the new filename format\n\nhttps://claude.ai/code/session_01RaftjaLecZSFEcnUpaVzdn