### PR TITLE
Respect system light/dark theme preference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,5 +28,5 @@ target_link_options(chronos PRIVATE
 
 target_link_libraries(chronos PRIVATE
     -Wl,-Bstatic winpthread -Wl,-Bdynamic
-    gdi32 user32 dwmapi shell32
+    gdi32 user32 dwmapi shell32 advapi32
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,6 +522,21 @@ static void handle(HWND hwnd, int act) {
     sync_timer(hwnd);
 }
 
+// ─── Theme detection ─────────────────────────────────────────────────────────
+static bool system_prefers_dark() {
+    HKEY key;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                      0, KEY_READ, &key) == ERROR_SUCCESS) {
+        DWORD val = 0, size = sizeof(val);
+        bool ok = RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
+                                   (LPBYTE)&val, &size) == ERROR_SUCCESS;
+        RegCloseKey(key);
+        if (ok) return val == 0;
+    }
+    return true; // default to dark
+}
+
 // ─── WndProc ──────────────────────────────────────────────────────────────────
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     switch (msg) {
@@ -534,7 +549,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         if (!hFontLarge) hFontLarge = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         if (!hFontSm)    hFontSm   = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         SetTimer(hwnd, 1, 100, nullptr);
-        BOOL dark = TRUE;
+        BOOL dark = system_prefers_dark() ? TRUE : FALSE;
         DwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */,
                               &dark, sizeof(dark));
         load_config(hwnd);


### PR DESCRIPTION
## Summary\n- Query the Windows registry (`AppsUseLightTheme`) to detect the user's theme preference\n- Apply dark mode DWM attribute only when the system is set to dark theme\n- Falls back to dark mode if registry detection fails\n- Links `advapi32` for registry API access\n\nCloses #7\n\n## Test plan\n- [ ] Set Windows theme to dark and verify the app title bar is dark\n- [ ] Set Windows theme to light and verify the app title bar is light\n- [ ] Verify the app still defaults to dark on systems where registry detection fails\n\nhttps://claude.ai/code/session_01RaftjaLecZSFEcnUpaVzdn