### PR TITLE
Fix #74: remove blank space at bottom of stopwatch/timer sections

### DIFF
--- a/src/layout.ixx
+++ b/src/layout.ixx
@@ -5,8 +5,8 @@ constexpr int STANDARD_DPI = 96;
 export struct Layout {
     int bar_h  =  36;
     int clk_h  =  62;
-    int sw_h   = 100;
-    int tmr_h  = 118;
+    int sw_h   =  96;
+    int tmr_h  = 114;
     int btn_h  =  28;
 
     int w_pin  = 44;
@@ -29,8 +29,8 @@ export struct Layout {
         dpi     = new_dpi;
         bar_h   = dpi_scale(36);
         clk_h   = dpi_scale(62);
-        sw_h    = dpi_scale(100);
-        tmr_h   = dpi_scale(118);
+        sw_h    = dpi_scale(96);
+        tmr_h   = dpi_scale(114);
         btn_h   = dpi_scale(28);
         w_pin   = dpi_scale(44);
         w_clk   = dpi_scale(48);

--- a/src/painting.ixx
+++ b/src/painting.ixx
@@ -284,7 +284,7 @@ static int paint_timers(HDC hdc, int cw, int y, PaintCtx& ctx, sc::time_point no
             tmr_act(i, A_TMR_RST), ctx);
 
         int pm_sz = layout.dpi_scale(22), pm_margin = layout.dpi_scale(6);
-        int pm_top = y + layout.tmr_h - pm_sz - layout.dpi_scale(4);
+        int pm_top = y + layout.tmr_h - pm_sz;
         if ((int)ctx.app.timers.size() < Config::MAX_TIMERS)
             btn(hdc, {cw-pm_margin-pm_sz, pm_top, cw-pm_margin, pm_top+pm_sz},
                 false, L"+", tmr_act(i, A_TMR_ADD), ctx);

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -31,8 +31,8 @@ TEST_CASE("Layout update_for_dpi: standard 96 DPI", "[layout]") {
     l.update_for_dpi(96);
     REQUIRE(l.bar_h == 36);
     REQUIRE(l.clk_h == 62);
-    REQUIRE(l.sw_h == 100);
-    REQUIRE(l.tmr_h == 118);
+    REQUIRE(l.sw_h == 96);
+    REQUIRE(l.tmr_h == 114);
     REQUIRE(l.btn_h == 28);
 }
 
@@ -41,8 +41,8 @@ TEST_CASE("Layout update_for_dpi: 192 DPI doubles values", "[layout]") {
     l.update_for_dpi(192);
     REQUIRE(l.bar_h == 72);
     REQUIRE(l.clk_h == 124);
-    REQUIRE(l.sw_h == 200);
-    REQUIRE(l.tmr_h == 236);
+    REQUIRE(l.sw_h == 192);
+    REQUIRE(l.tmr_h == 228);
     REQUIRE(l.btn_h == 56);
 }
 
@@ -63,7 +63,7 @@ TEST_CASE("client_height_for: all sections visible", "[layout]") {
     l.update_for_dpi(96);
     LayoutState s{true, true, true, 2};
     // bar_h + clk_h + sw_h + 2*tmr_h
-    REQUIRE(client_height_for(l, s) == 36 + 62 + 100 + 2 * 118);
+    REQUIRE(client_height_for(l, s) == 36 + 62 + 96 + 2 * 114);
 }
 
 TEST_CASE("client_height_for: none visible", "[layout]") {
@@ -84,5 +84,5 @@ TEST_CASE("client_height_for: timers with 3 slots", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
     LayoutState s{false, false, true, 3};
-    REQUIRE(client_height_for(l, s) == 36 + 3 * 118);
+    REQUIRE(client_height_for(l, s) == 36 + 3 * 114);
 }


### PR DESCRIPTION
## Summary
- `sw_h` reduced from 100 → 96: stopwatch content ends at y+96, section now matches exactly
- `tmr_h` reduced from 118 → 114: timer content ends at y+114, section now matches exactly
- `pm_top` formula loses its redundant `-dpi_scale(4)` offset so +/− buttons stay at the same screen position (y+tmr_h−pm_sz)
- Unit tests updated for new section heights

## Test plan
- [ ] Build and run — confirm 4px blank strip at the bottom of the stopwatch and timer sections is gone
- [ ] All layout unit tests pass
- [ ] Window height updates correctly when toggling Clock / Stopwatch / Timers on and off

Closes #74

https://claude.ai/code/session_01E8fcREr3Fg72dBjFsgem97