### PR TITLE
Fix #75: save normal window rect when closing from system tray

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,7 +200,15 @@ static void save_config(HWND hwnd, const WndState& s) {
         cfg.timer_labels[i] = std::string(s.app.timers[i].label.begin(), s.app.timers[i].label.end());
     }
     if (hwnd) {
-        RECT wr; GetWindowRect(hwnd, &wr);
+        RECT wr;
+        if (IsIconic(hwnd)) {
+            WINDOWPLACEMENT wp{};
+            wp.length = sizeof(wp);
+            GetWindowPlacement(hwnd, &wp);
+            wr = wp.rcNormalPosition;
+        } else {
+            GetWindowRect(hwnd, &wr);
+        }
         cfg.pos_valid = true;
         cfg.win_x = wr.left;
         cfg.win_y = wr.top;


### PR DESCRIPTION
## Summary

- When closing the app while minimized to the system tray, `GetWindowRect` returns the iconic/parked rect (off-screen at ~-32000 with ~160px width)
- On next launch the saved width gets clamped to the minimum (264px), so the window no longer starts at the user's configured size
- Fix: use `GetWindowPlacement.rcNormalPosition` when `IsIconic(hwnd)` is true, which gives the pre-minimise position and width

## Test plan

- [ ] Resize window to a comfortable width (e.g. 400px)
- [ ] Minimize window to system tray (click minimize button)
- [ ] Right-click tray icon → Exit
- [ ] Relaunch app — window should restore to ~400px width, not shrink to minimum

Closes #75

https://claude.ai/code/session_01S1NRqehM7oMMz1EbWgZDnV