### PR TITLE
Fix O(n²) cumulative lap time calculation

### DIFF
--- a/src/actions.ixx
+++ b/src/actions.ixx
@@ -92,9 +92,7 @@ export HandleResult dispatch_action(App& app, int act, sc::time_point now,
                 if (f) {
                     const auto& laps = app.sw.laps();
                     auto n = laps.size();
-                    sc::duration cum{};
-                    for (auto& l : laps) cum += l;
-                    f << format_lap_row(n, laps.back(), cum) << L'\n';
+                    f << format_lap_row(n, laps.back(), app.sw.cumulative()) << L'\n';
                     app.lap_write_failed = false;
                 } else {
                     app.lap_write_failed = true;

--- a/src/stopwatch.ixx
+++ b/src/stopwatch.ixx
@@ -26,6 +26,7 @@ export struct Stopwatch {
         if (running_) {
             laps_.push_back(now - last_lap_time_);
             last_lap_time_ = now;
+            cumulative_   += laps_.back();
         }
     }
 
@@ -34,6 +35,7 @@ export struct Stopwatch {
         start_time_    = {};
         last_lap_time_ = {};
         accumulated_   = {};
+        cumulative_    = {};
         laps_.clear();
     }
 
@@ -47,10 +49,13 @@ export struct Stopwatch {
 
     const std::vector<dur>& laps() const { return laps_; }
 
+    dur cumulative() const { return cumulative_; }
+
 private:
     bool             running_       = false;
     tp               start_time_    = {};
     tp               last_lap_time_ = {};
     dur              accumulated_   = {};
+    dur              cumulative_    = {};
     std::vector<dur> laps_;
 };

--- a/tests/test_stopwatch.cpp
+++ b/tests/test_stopwatch.cpp
@@ -43,6 +43,18 @@ TEST_CASE("Stopwatch lap recording", "[stopwatch]") {
     REQUIRE(sw.laps()[1] == milliseconds(250));
 }
 
+TEST_CASE("Stopwatch cumulative lap time", "[stopwatch]") {
+    Stopwatch sw;
+    sw.start(at_ms(0));
+    REQUIRE(sw.cumulative() == dur::zero());
+    sw.lap(at_ms(100));
+    REQUIRE(sw.cumulative() == milliseconds(100));
+    sw.lap(at_ms(350));
+    REQUIRE(sw.cumulative() == milliseconds(350));
+    sw.reset();
+    REQUIRE(sw.cumulative() == dur::zero());
+}
+
 TEST_CASE("Stopwatch lap ignored when not running", "[stopwatch]") {
     Stopwatch sw;
     sw.lap(at_ms(100));


### PR DESCRIPTION
## Summary

- Adds a `cumulative_` field to `Stopwatch`, updated in O(1) on each `lap()` call and reset in `reset()`
- Replaces the O(n²) per-lap loop in `actions.ixx` with a single call to `app.sw.cumulative()`
- Adds a unit test covering the new `cumulative()` accessor

Closes #82

https://claude.ai/code/session_0133gVusfEtpJAfFopQBLq7w