### PR TITLE
Feature #87: Display lap count and latest split on stopwatch

### DIFF
--- a/src/layout.ixx
+++ b/src/layout.ixx
@@ -5,7 +5,7 @@ constexpr int STANDARD_DPI = 96;
 export struct Layout {
     int bar_h  =  36;
     int clk_h  =  62;
-    int sw_h   =  96;
+    int sw_h   = 116;
     int tmr_h  = 114;
     int btn_h  =  28;
 
@@ -29,7 +29,7 @@ export struct Layout {
         dpi     = new_dpi;
         bar_h   = dpi_scale(36);
         clk_h   = dpi_scale(62);
-        sw_h    = dpi_scale(96);
+        sw_h    = dpi_scale(116);
         tmr_h   = dpi_scale(114);
         btn_h   = dpi_scale(28);
         w_pin   = dpi_scale(44);

--- a/src/painting.ixx
+++ b/src/painting.ixx
@@ -188,12 +188,21 @@ static int paint_stopwatch(HDC hdc, int cw, int y, PaintCtx& ctx, sc::time_point
     btn(hdc, {bx0+bw+gap,     by0, bx0+2*bw+gap,    by0+bh}, false,   L"Lap",                       A_SW_LAP, ctx);
     btn(hdc, {bx0+2*(bw+gap), by0, bx0+3*bw+2*gap,  by0+bh}, false,   L"Reset",                     A_SW_RESET, ctx);
 
+    auto& laps = ctx.app.sw.laps();
+    if (!laps.empty()) {
+        auto info = std::format(L"Lap {}  \u2014  {}", laps.size(),
+                                format_stopwatch_short(laps.back()));
+        SetTextColor(hdc, th.dim);
+        RECT ir{0, by0+bh+layout.dpi_scale(4), cw, by0+bh+layout.dpi_scale(22)};
+        DrawTextW(hdc, info.c_str(), -1, &ir, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    }
+
     bool has_file = !ctx.app.sw_lap_file.empty();
     int  gbw = layout.dpi_scale(100), gbh = layout.dpi_scale(18);
     auto lap_label = ctx.app.lap_write_failed ? L"Get Laps (!)" : L"Get Laps";
     auto lap_col = ctx.app.lap_write_failed ? th.expire
                  : has_file ? th.btn : th.dim;
-    btn(hdc, {(cw-gbw)/2, by0+bh+layout.dpi_scale(4), (cw+gbw)/2, by0+bh+layout.dpi_scale(4)+gbh},
+    btn(hdc, {(cw-gbw)/2, by0+bh+layout.dpi_scale(24), (cw+gbw)/2, by0+bh+layout.dpi_scale(24)+gbh},
         false, lap_label, has_file ? A_SW_GET : 0, ctx, lap_col);
     return y + layout.sw_h;
 }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Layout update_for_dpi: standard 96 DPI", "[layout]") {
     l.update_for_dpi(96);
     REQUIRE(l.bar_h == 36);
     REQUIRE(l.clk_h == 62);
-    REQUIRE(l.sw_h == 96);
+    REQUIRE(l.sw_h == 116);
     REQUIRE(l.tmr_h == 114);
     REQUIRE(l.btn_h == 28);
 }
@@ -41,7 +41,7 @@ TEST_CASE("Layout update_for_dpi: 192 DPI doubles values", "[layout]") {
     l.update_for_dpi(192);
     REQUIRE(l.bar_h == 72);
     REQUIRE(l.clk_h == 124);
-    REQUIRE(l.sw_h == 192);
+    REQUIRE(l.sw_h == 232);
     REQUIRE(l.tmr_h == 228);
     REQUIRE(l.btn_h == 56);
 }
@@ -63,7 +63,7 @@ TEST_CASE("client_height_for: all sections visible", "[layout]") {
     l.update_for_dpi(96);
     LayoutState s{true, true, true, 2};
     // bar_h + clk_h + sw_h + 2*tmr_h
-    REQUIRE(client_height_for(l, s) == 36 + 62 + 96 + 2 * 114);
+    REQUIRE(client_height_for(l, s) == 36 + 62 + 116 + 2 * 114);
 }
 
 TEST_CASE("client_height_for: none visible", "[layout]") {


### PR DESCRIPTION
## Summary

- Adds a lap info line between the Stop/Lap/Reset buttons and the Get Laps button
- When laps exist, shows `Lap N  —  MM:SS.mmm` (count + most recent split) in dim text
- Increases `sw_h` from 96 → 116 to accommodate the new line
- Updates layout tests to match new `sw_h` values

Closes #87

## Test plan

- [ ] Build passes with no errors
- [ ] Tests pass (layout sw_h assertions updated)
- [ ] With no laps recorded, the lap info line is not shown
- [ ] After recording one or more laps, the correct lap count and last split appear

https://claude.ai/code/session_0123yH6YxrUtNfxWEW5G5LFf