### PR TITLE
feat(actions,input): add A_TMR_RST_ALL + Shift+R / Ctrl+R to reset all timers (#240)

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -24,6 +24,7 @@ enum Act {
     A_SW_COPY,
     A_THEME,
     A_CLK_CYCLE,
+    A_TMR_RST_ALL, // Reset every timer slot in one action
     A_TMR_BASE = 100,
 };
 
@@ -151,6 +152,22 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
     case A_CLK_CYCLE:
         app.clock_view = (ClockView)(((int)app.clock_view + 1) % CLOCK_VIEW_COUNT);
         r.save_config = true;
+        break;
+    case A_TMR_RST_ALL:
+        // Reset every timer slot. Mirrors per-slot A_TMR_RST exactly so
+        // pomodoro phase, work elapsed, and notification flags are all
+        // cleared the same way they would be on a single Shift+1/2/3.
+        for (auto& ts : app.timers) {
+            ts.notified = false;
+            if (ts.pomodoro) {
+                ts.pomodoro_phase = 0;
+                ts.dur = std::chrono::seconds{POMODORO_WORK_SECS};
+                ts.label = pomodoro_phase_label(0);
+                ts.pomodoro_work_elapsed = {};
+            }
+            ts.t.reset();
+            ts.t.set(ts.dur);
+        }
         break;
     default:
         if (act >= A_TMR_BASE) {

--- a/src/input_keyboard.hpp
+++ b/src/input_keyboard.hpp
@@ -42,14 +42,36 @@ inline std::optional<LRESULT> dispatch_keyboard(HWND hwnd, UINT msg, WPARAM wp, 
         case 'C':
             if (plain_key() && s.app.show_sw) handle(hwnd, A_SW_COPY, s);
             return 0;
-        case 'R':
-            if (plain_key()) {
+        case 'R': {
+            // R alone: stopwatch reset (when shown) or first-timer reset.
+            // Shift+R / Ctrl+R: reset ALL timers in one action so users
+            // with multiple slots don't have to press Shift+1/2/3
+            // separately. Ctrl+R is the always-available fallback (works
+            // even when the stopwatch view is taking R alone for
+            // stopwatch reset).
+            //
+            // Order matters: plain_key() does NOT check Shift, so we
+            // must test the modifier branches BEFORE the plain-R path,
+            // otherwise Shift+R falls into plain-R and silently resets
+            // only the first timer.
+            const bool ctrl = GetKeyState(VK_CONTROL) < 0;
+            const bool shift = GetKeyState(VK_SHIFT) < 0;
+            const bool alt = GetKeyState(VK_MENU) < 0;
+            const bool winkey =
+                GetKeyState(VK_LWIN) < 0 || GetKeyState(VK_RWIN) < 0;
+            if (!alt && !winkey && (ctrl ^ shift)) {
+                // Exactly one of Ctrl or Shift is held (no Alt/Win).
+                if (s.app.show_tmr && !s.app.timers.empty())
+                    handle(hwnd, A_TMR_RST_ALL, s);
+            } else if (plain_key() && !shift) {
+                // Truly plain R (no modifiers at all).
                 if (s.app.show_sw)
                     handle(hwnd, A_SW_RESET, s);
                 else if (s.app.show_tmr && !s.app.timers.empty())
                     handle(hwnd, tmr_act(0, A_TMR_RST), s);
             }
             return 0;
+        }
         case 'T':
             if (plain_key()) handle(hwnd, A_TOPMOST, s);
             return 0;

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -128,6 +128,7 @@ inline void paint_help(HDC hdc, int cw, int y_bottom, PaintCtx& ctx) {
         {L"D", L"Cycle theme: Auto \u2192 Dark \u2192 Light"},
         {L"1-3", L"Start/Stop timer 1-3"},
         {L"Shift+1-3", L"Reset timer 1-3"},
+        {L"Shift+R / Ctrl+R", L"Reset all timers"},
         {L"+ / =", L"Add a timer slot"},
         {L"-", L"Remove last timer slot"},
         {L"H / ?", L"Toggle this help"},

--- a/tests/test_actions.cpp
+++ b/tests/test_actions.cpp
@@ -337,6 +337,69 @@ TEST_CASE("A_TMR_RST resets timer and clears notified flag", "[actions]") {
     REQUIRE_FALSE(app.timers[0].notified);
 }
 
+// ─── timer reset all ─────────────────────────────────────────────────────────
+
+TEST_CASE("A_TMR_RST_ALL resets every timer slot", "[actions]") {
+    App app;
+    // Add two more timers so we have three total to verify the loop hits
+    // every slot, not just the first.
+    dispatch_action(app, tmr_act(0, A_TMR_ADD), t0(), {});
+    dispatch_action(app, tmr_act(0, A_TMR_ADD), t0(), {});
+    REQUIRE((int)app.timers.size() == 3);
+
+    // Touch every slot so reset has something visible to undo, and set a
+    // notified flag we expect cleared.
+    for (int i = 0; i < 3; ++i) {
+        app.timers[i].notified = true;
+        dispatch_action(app, tmr_act(i, A_TMR_START), t0(), {});
+        REQUIRE(app.timers[i].t.touched());
+    }
+
+    auto r = dispatch_action(app, A_TMR_RST_ALL, at_ms(1000), {});
+
+    for (int i = 0; i < 3; ++i) {
+        REQUIRE_FALSE(app.timers[i].t.is_running());
+        REQUIRE_FALSE(app.timers[i].t.touched());
+        REQUIRE_FALSE(app.timers[i].notified);
+    }
+    // Reset is a per-state mutation, not a structural change, so neither
+    // resize nor save_config should fire.
+    REQUIRE_FALSE(r.resize);
+    REQUIRE_FALSE(r.save_config);
+}
+
+TEST_CASE("A_TMR_RST_ALL on Pomodoro timer resets phase + work elapsed", "[actions]") {
+    App app;
+    // Toggle Pomodoro on, then advance the phase artificially so the
+    // reset-all has a non-trivial state to clear.
+    dispatch_action(app, tmr_act(0, A_TMR_POMO), t0(), {});
+    REQUIRE(app.timers[0].pomodoro);
+    app.timers[0].pomodoro_phase = 2;
+    app.timers[0].pomodoro_work_elapsed = std::chrono::seconds{45};
+    app.timers[0].notified = true;
+
+    dispatch_action(app, A_TMR_RST_ALL, at_ms(2000), {});
+
+    REQUIRE(app.timers[0].pomodoro_phase == 0);
+    REQUIRE(app.timers[0].pomodoro_work_elapsed == std::chrono::seconds{0});
+    REQUIRE_FALSE(app.timers[0].notified);
+}
+
+TEST_CASE("A_TMR_RST_ALL is a no-op when there are no timers", "[actions]") {
+    App app;
+    app.timers.clear();
+    // Must not crash and must not mark anything as needing save/resize.
+    auto r = dispatch_action(app, A_TMR_RST_ALL, t0(), {});
+    REQUIRE_FALSE(r.resize);
+    REQUIRE_FALSE(r.save_config);
+}
+
+TEST_CASE("A_TMR_RST_ALL wants_blink returns true", "[actions]") {
+    // Reset is a state-mutating action, so the UI should blink to
+    // acknowledge it -- matching the per-slot A_TMR_RST behavior.
+    REQUIRE(wants_blink(A_TMR_RST_ALL));
+}
+
 // ─── timer add / delete ──────────────────────────────────────────────────────
 
 TEST_CASE("A_TMR_ADD inserts timer after current index", "[actions]") {


### PR DESCRIPTION
## Summary

Adds the `A_TMR_RST_ALL` action and `Shift+R` / `Ctrl+R` keyboard shortcuts to reset every timer slot in one keypress, per the issue's spec (action approach preferred over keyboard-handler loop).

Closes #240

## Changes

### `src/actions.hpp`

- New `A_TMR_RST_ALL` enum value (sits between `A_CLK_CYCLE` and `A_TMR_BASE`).
- New `dispatch_action` case that loops `app.timers` and applies the same reset that per-slot `A_TMR_RST` already performs (notified flag, pomodoro phase + `POMODORO_WORK_SECS`, label, `pomodoro_work_elapsed`, then `t.reset()` + `t.set(dur)`). Behavior matches pressing Shift+1, Shift+2, Shift+3 in succession.
- `wants_blink(A_TMR_RST_ALL)` falls through to `true` via the `default` arm, matching per-slot `A_TMR_RST`.

### `src/input_keyboard.hpp`

- `R` keydown now branches:
  - **Shift+R** OR **Ctrl+R** (no Alt/Win) → `A_TMR_RST_ALL` when the timer view is visible.
  - **Plain R** (no modifiers at all) → existing `A_SW_RESET` (when stopwatch shown) or `tmr_act(0, A_TMR_RST)` (first-timer reset).
- The branch order is critical and the diff has a comment about it: `plain_key()` deliberately doesn't check Shift, so the modifier branch must be tested **before** the plain-R branch, or `Shift+R` falls into plain-R and silently resets only the first timer. The first draft of this change had that bug — caught during a self-review pass.
- `(ctrl ^ shift)` ensures only one of the two modifiers is held; Ctrl+Shift+R is intentionally not bound (no documented behavior).

### `src/painting.hpp`

- Help overlay shows `Shift+R / Ctrl+R` between the existing `Shift+1-3` and `+ / =` rows so the new shortcut is discoverable.

### `tests/test_actions.cpp`

Four new Catch2 tests at the action level (the keyboard handler is `windows.h`-only so it's not unit-testable here):

| Test | What it covers |
|---|---|
| `A_TMR_RST_ALL resets every timer slot` | 3 timers added (`A_TMR_ADD x2`), each started with `notified=true`. After `A_TMR_RST_ALL`, all 3 are `!is_running()`, `!touched()`, `!notified`. Asserts `!resize` and `!save_config` (reset is state mutation, not structural). |
| `A_TMR_RST_ALL on Pomodoro timer resets phase + work elapsed` | Pomodoro toggled on, phase=2, `work_elapsed=45s`, `notified=true`. After reset: `phase==0`, `work_elapsed==0s`, `!notified`. |
| `A_TMR_RST_ALL is a no-op when there are no timers` | Empty `app.timers`. Verifies no crash and no save/resize flags fire. |
| `A_TMR_RST_ALL wants_blink returns true` | Pins blink-on-reset matching per-slot `A_TMR_RST`. |

## Verification

```
$ cmake --preset test
-- Configuring done (1.6s)
-- Generating done (0.0s)
-- Build files have been written to: build

$ cmake --build build
[118/118] Linking CXX executable chronos_tests

$ ctest --test-dir build
100% tests passed, 0 tests failed out of 189
```

Was 185 tests on `upstream/main`; the 4 new ones bring the count to 189.

## Notes

The keyboard-handler change can't be exercised by the `tests/` Catch2 suite because it requires `windows.h`. The branch logic is small and reads against the existing `'1' / '2' / '3'` precedent (which uses `GetKeyState(VK_SHIFT) < 0` to choose `A_TMR_RST` vs `A_TMR_START`), so the modifier handling here mirrors the same pattern.

This contribution was developed with AI assistance (Claude Code).
