### PR TITLE
fix: prevent extra space below bottom widget on vertical monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Chronos are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.5.2] — 2026-05-11
+
+### Fixed
+- Prevent extra empty space below the bottom widget when the window is snapped or resized on portrait (vertical) monitors — lock maximum window height to content height via `WM_GETMINMAXINFO` and correct oversized frames in `WM_SIZE` (#263)
+
 ## [1.5.1] — 2026-05-11
 
 ### Fixed

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -67,6 +67,12 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             ShowWindow(hwnd, SW_HIDE);
             return 0;
         }
+        {
+            RECT cr;
+            GetClientRect(hwnd, &cr);
+            if (cr.bottom > client_height(*s))
+                resize_window(hwnd, *s);
+        }
         break;
     case WM_TRAYICON: {
         auto tray_restore = [&] {
@@ -127,6 +133,7 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         RECT adj_h{0, 0, 0, client_height(*s)};
         AdjustWindowRectEx(&adj_h, ws, FALSE, 0);
         m->ptMinTrackSize.y = adj_h.bottom - adj_h.top;
+        m->ptMaxTrackSize.y = m->ptMinTrackSize.y;
         return 0;
     }
     case WM_DPICHANGED: {


### PR DESCRIPTION
## Summary

- Lock window max track height to content height in `WM_GETMINMAXINFO`, preventing Windows snap from stretching the window beyond its content on portrait displays
- Add `WM_SIZE` fallback that corrects oversized frames after snap operations that bypass min/max info
- Add v1.5.2 changelog entry

Closes #263

https://claude.ai/code/session_01Nub7Y7Fn4bS3cs4uV7mCDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nub7Y7Fn4bS3cs4uV7mCDH)_