### PR TITLE
feat: add configurable notification sound on timer expiry (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Chronos are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.7.0] — 2026-05-12
+
+### Added
+- Configurable notification sound on timer expiry — toggle on/off via **Appearance → Notifications** in the settings panel (default: on) (#267)
+- Sound setting persisted to `config.ini` and respected by all timers including Pomodoro phase transitions
+
 ## [1.6.0] — 2026-05-12
 
 ### Added

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -39,6 +39,7 @@ struct App {
     bool show_sw = true;
     bool show_tmr = true;
     bool topmost = false;
+    bool sound_on_expiry = true;
     ThemeMode theme_mode = ThemeMode::Auto;
     ClockView clock_view = ClockView::H24_HMS;
     int pomodoro_work_secs = 25 * 60;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,6 +15,7 @@ struct Config {
     bool show_sw = true;
     bool show_tmr = true;
     bool topmost = false;
+    bool sound_on_expiry = true;
     ThemeMode theme_mode = ThemeMode::Auto;
     static constexpr int MAX_TIMERS = 20;
     static constexpr int MAX_LABEL_LEN = 20;

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -42,6 +42,7 @@ inline void save_config(HWND hwnd, const WndState& s) {
     cfg.show_sw = s.app.show_sw;
     cfg.show_tmr = s.app.show_tmr;
     cfg.topmost = s.app.topmost;
+    cfg.sound_on_expiry = s.app.sound_on_expiry;
     cfg.theme_mode = s.app.theme_mode;
     cfg.pomodoro_work_secs = s.app.pomodoro_work_secs;
     cfg.pomodoro_short_secs = s.app.pomodoro_short_secs;
@@ -112,6 +113,7 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.show_sw = cfg.show_sw;
     s.app.show_tmr = cfg.show_tmr;
     s.app.topmost = cfg.topmost;
+    s.app.sound_on_expiry = cfg.sound_on_expiry;
     s.app.theme_mode = cfg.theme_mode;
     s.app.pomodoro_work_secs = cfg.pomodoro_work_secs;
     s.app.pomodoro_short_secs = cfg.pomodoro_short_secs;

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -12,8 +12,8 @@
 
 inline bool config_write(const Config& c, std::ostream& f) {
     const char* theme_str = c.theme_mode == ThemeMode::Dark ? "dark" : c.theme_mode == ThemeMode::Light ? "light" : "auto";
-    f << std::format("show_clk={}\nshow_sw={}\nshow_tmr={}\ntopmost={}\ntheme={}\nclock_view={}\nnum_timers={}\n", c.show_clk ? 1 : 0,
-                     c.show_sw ? 1 : 0, c.show_tmr ? 1 : 0, c.topmost ? 1 : 0, theme_str, (int)c.clock_view, c.num_timers);
+    f << std::format("show_clk={}\nshow_sw={}\nshow_tmr={}\ntopmost={}\nsound_on_expiry={}\ntheme={}\nclock_view={}\nnum_timers={}\n", c.show_clk ? 1 : 0,
+                     c.show_sw ? 1 : 0, c.show_tmr ? 1 : 0, c.topmost ? 1 : 0, c.sound_on_expiry ? 1 : 0, theme_str, (int)c.clock_view, c.num_timers);
     Config defaults;
     if (c.pomodoro_work_secs != defaults.pomodoro_work_secs ||
         c.pomodoro_short_secs != defaults.pomodoro_short_secs ||
@@ -95,6 +95,8 @@ inline bool config_read(Config& c, std::istream& f) {
             c.show_tmr = val != 0;
         else if (key == "topmost")
             c.topmost = val != 0;
+        else if (key == "sound_on_expiry")
+            c.sound_on_expiry = val != 0;
         else if (key == "num_timers")
             c.num_timers = clamp_int(val, 1, Config::MAX_TIMERS);
         else if (key == "win_x") {

--- a/src/polling.hpp
+++ b/src/polling.hpp
@@ -65,7 +65,7 @@ inline void handle_wm_timer(HWND hwnd, WndState& s) {
         auto& ts = s.app.timers[i];
         if (ts.t.touched() && ts.t.expired(now) && !ts.notified) {
             ts.notified = true;
-            MessageBeep(MB_ICONASTERISK);
+            if (s.app.sound_on_expiry) MessageBeep(MB_ICONASTERISK);
             FLASHWINFO fi{};
             fi.cbSize = sizeof(fi);
             fi.hwnd = hwnd;

--- a/src/settings_dialog.hpp
+++ b/src/settings_dialog.hpp
@@ -121,6 +121,7 @@ struct HitRects {
     RECT sidebar[TAB_COUNT];
     RECT theme[3];
     RECT clock[4];
+    RECT sound;
 };
 
 inline HitRects compute_rects(HWND dlg) {
@@ -137,6 +138,8 @@ inline HitRects compute_rects(HWND dlg) {
     h.clock[1] = map_dlu(dlg, 70, 57, 100, 13);
     h.clock[2] = map_dlu(dlg, 70, 72, 100, 13);
     h.clock[3] = map_dlu(dlg, 70, 87, 100, 13);
+
+    h.sound = map_dlu(dlg, 70, 97, 100, 13);
     return h;
 }
 
@@ -144,6 +147,7 @@ struct Params {
     int active_tab = TAB_APPEARANCE;
     ThemeMode theme_mode;
     ClockView clock_view;
+    bool sound_on_expiry;
     int work_min, short_min, long_min;
     DlgStyle style;
     HitRects rects{};
@@ -275,6 +279,12 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             for (int i = 0; i < 3; ++i)
                 paint_option_btn(hdc, p->rects.theme[i], names[i],
                                 (int)p->theme_mode == i, s);
+
+            RECT slbl = map_dlu(dlg, 70, 88, 80, 8);
+            s.draw_label(hdc, slbl, L"Notifications");
+            paint_option_btn(hdc, p->rects.sound,
+                            p->sound_on_expiry ? L"Sound: on" : L"Sound: off",
+                            p->sound_on_expiry, s);
         } else if (p->active_tab == TAB_CLOCK) {
             RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
             s.draw_label(hdc, lbl, L"Format");
@@ -366,6 +376,11 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
                     return TRUE;
                 }
             }
+            if (PtInRect(&p->rects.sound, pt)) {
+                p->sound_on_expiry = !p->sound_on_expiry;
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
         }
 
         if (p->active_tab == TAB_CLOCK) {
@@ -432,6 +447,7 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
         .active_tab = TAB_APPEARANCE,
         .theme_mode = app.theme_mode,
         .clock_view = app.clock_view,
+        .sound_on_expiry = app.sound_on_expiry,
         .work_min  = app.pomodoro_work_secs / 60,
         .short_min = app.pomodoro_short_secs / 60,
         .long_min  = app.pomodoro_long_secs / 60,
@@ -448,6 +464,7 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
     if (result != IDOK) return false;
     app.theme_mode = p.theme_mode;
     app.clock_view = p.clock_view;
+    app.sound_on_expiry = p.sound_on_expiry;
     app.pomodoro_work_secs = p.work_min * 60;
     app.pomodoro_short_secs = p.short_min * 60;
     app.pomodoro_long_secs = p.long_min * 60;

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -372,6 +372,24 @@ TEST_CASE("Config empty label value produces empty string", "[config]") {
     REQUIRE(c.timer_labels[0].empty());
 }
 
+TEST_CASE("Config sound_on_expiry defaults to true", "[config]") {
+    Config c;
+    REQUIRE(c.sound_on_expiry);
+}
+
+TEST_CASE("Config sound_on_expiry round-trip", "[config]") {
+    for (bool val : {true, false}) {
+        Config orig;
+        orig.sound_on_expiry = val;
+        std::ostringstream os;
+        config_write(orig, os);
+        Config back;
+        std::istringstream is(os.str());
+        config_read(back, is);
+        REQUIRE(back.sound_on_expiry == val);
+    }
+}
+
 TEST_CASE("Config whitespace around equals is ignored", "[config]") {
     std::istringstream is("timer0 = 60\nshow_clk = 0\n");
     Config c;


### PR DESCRIPTION
## Summary

- Add `sound_on_expiry` toggle (default: on) that controls `MessageBeep` on timer expiry
- Expose toggle in Settings > Appearance > Notifications as a clickable button
- Persisted to `config.ini`, applies to all timers including Pomodoro phase transitions
- 2 new unit tests for config default and round-trip serialization

Closes #267

## Test plan

- [x] All 215 tests pass (213 existing + 2 new)
- [x] Build succeeds with clang++-18 on Linux
- [ ] Verify sound plays on timer expiry with setting enabled (Windows)
- [ ] Verify no sound on timer expiry with setting disabled (Windows)
- [ ] Verify setting persists across app restart

---
_Generated by [Claude Code](https://claude.ai/code/session_0177gfExHtzQy78mxbNp7WRp)_