### PR TITLE
feat: configurable pomodoro long-break cadence and auto-start toggle

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -200,9 +200,9 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         for (auto& ts : app.timers) {
             ts.notified = false;
             if (ts.pomodoro) {
-                ts.pomodoro_phase = PomodoroPhase::Work1;
-                ts.dur = std::chrono::seconds{POMODORO_WORK_SECS};
-                ts.label = pomodoro_phase_label(PomodoroPhase::Work1);
+                ts.pomodoro_phase = 0;
+                ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
+                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
                 ts.pomodoro_work_elapsed = {};
             }
             ts.t.reset();
@@ -226,9 +226,9 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
             } else if (off == A_TMR_RST) {
                 ts.notified = false;
                 if (ts.pomodoro) {
-                    ts.pomodoro_phase = PomodoroPhase::Work1;
-                    ts.dur = std::chrono::seconds{POMODORO_WORK_SECS};
-                    ts.label = pomodoro_phase_label(PomodoroPhase::Work1);
+                    ts.pomodoro_phase = 0;
+                    ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
+                    ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
                     ts.pomodoro_work_elapsed = {};
                 }
                 ts.t.reset();
@@ -254,10 +254,10 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
                         ts.label.clear();
                     } else {
                         ts.pomodoro = true;
-                        ts.pomodoro_phase = PomodoroPhase::Work1;
+                        ts.pomodoro_phase = 0;
                         ts.pomodoro_work_elapsed = {};
                         ts.dur = seconds{app.pomodoro_work_secs};
-                        ts.label = pomodoro_phase_label(PomodoroPhase::Work1);
+                        ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
                         ts.notified = false;
                         ts.t.reset();
                         ts.t.set(ts.dur);
@@ -270,15 +270,16 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
                         auto elapsed = duration_cast<seconds>(ts.t.total_elapsed(now));
                         ts.pomodoro_work_elapsed += elapsed;
                     }
-                    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase);
+                    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, app.pomodoro_cadence);
                     auto secs = seconds{pomodoro_phase_secs(ts.pomodoro_phase,
-                        app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs)};
+                        app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs,
+                        app.pomodoro_cadence)};
                     ts.dur = secs;
                     ts.notified = false;
                     ts.t.reset();
                     ts.t.set(secs);
                     ts.t.start(now);
-                    ts.label = pomodoro_phase_label(ts.pomodoro_phase);
+                    ts.label = pomodoro_phase_label(ts.pomodoro_phase, app.pomodoro_cadence);
                     r.save_config = true;
                 }
             } else if (!ts.t.touched() && apply_timer_hms_adjust(ts, off)) {

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -13,22 +13,23 @@ struct TimerSlot {
     bool notified = false;
     std::wstring label;
     bool pomodoro = false;
-    PomodoroPhase pomodoro_phase = PomodoroPhase::Work1;
+    int pomodoro_phase = 0;
     std::chrono::seconds pomodoro_work_elapsed{};
 };
 
 inline void advance_pomodoro_phase(TimerSlot& ts, int work_secs, int short_secs, int long_secs,
+                                    int cadence, bool auto_start,
                                     std::chrono::steady_clock::time_point now) {
     if (pomodoro_is_work(ts.pomodoro_phase))
         ts.pomodoro_work_elapsed += ts.dur;
-    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase);
-    auto secs = std::chrono::seconds{pomodoro_phase_secs(ts.pomodoro_phase, work_secs, short_secs, long_secs)};
+    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, cadence);
+    auto secs = std::chrono::seconds{pomodoro_phase_secs(ts.pomodoro_phase, work_secs, short_secs, long_secs, cadence)};
     ts.dur = secs;
     ts.t.reset();
     ts.t.set(secs);
-    ts.t.start(now);
+    if (auto_start) ts.t.start(now);
     ts.notified = false;
-    ts.label = pomodoro_phase_label(ts.pomodoro_phase);
+    ts.label = pomodoro_phase_label(ts.pomodoro_phase, cadence);
 }
 
 struct App {
@@ -45,6 +46,8 @@ struct App {
     int pomodoro_work_secs = 25 * 60;
     int pomodoro_short_secs = 5 * 60;
     int pomodoro_long_secs = 15 * 60;
+    int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
+    bool pomodoro_auto_start = true;
     bool show_help = false;
     bool lap_write_failed = false;
     int blink_act = 0;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -43,6 +43,8 @@ struct Config {
     int pomodoro_work_secs = POMODORO_WORK_SECS;
     int pomodoro_short_secs = POMODORO_SHORT_BREAK_SECS;
     int pomodoro_long_secs = POMODORO_LONG_BREAK_SECS;
+    int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
+    bool pomodoro_auto_start = true;
     ClockView clock_view = ClockView::H24_HMS;
     Config() { timer_secs.fill(60); }
 };

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -47,6 +47,8 @@ inline void save_config(HWND hwnd, const WndState& s) {
     cfg.pomodoro_work_secs = s.app.pomodoro_work_secs;
     cfg.pomodoro_short_secs = s.app.pomodoro_short_secs;
     cfg.pomodoro_long_secs = s.app.pomodoro_long_secs;
+    cfg.pomodoro_cadence = s.app.pomodoro_cadence;
+    cfg.pomodoro_auto_start = s.app.pomodoro_auto_start;
     cfg.num_timers = (int)s.app.timers.size();
     auto now_steady = steady_clock::now();
     auto now_wall_ms = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
@@ -118,6 +120,8 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.pomodoro_work_secs = cfg.pomodoro_work_secs;
     s.app.pomodoro_short_secs = cfg.pomodoro_short_secs;
     s.app.pomodoro_long_secs = cfg.pomodoro_long_secs;
+    s.app.pomodoro_cadence = cfg.pomodoro_cadence;
+    s.app.pomodoro_auto_start = cfg.pomodoro_auto_start;
     int n = std::min(cfg.num_timers, Config::MAX_TIMERS);
     s.app.timers.resize(n);
     for (int i = 0; i < n; ++i) {
@@ -148,7 +152,7 @@ inline void load_config(HWND hwnd, WndState& s) {
     for (int i = 0; i < n; ++i) {
         auto& ts = s.app.timers[i];
         ts.pomodoro = cfg.timer_pomodoro[i];
-        ts.pomodoro_phase = static_cast<PomodoroPhase>(cfg.timer_pomodoro_phase[i]);
+        ts.pomodoro_phase = cfg.timer_pomodoro_phase[i];
         ts.pomodoro_work_elapsed = std::chrono::seconds{cfg.timer_pomodoro_work_secs[i]};
         if (cfg.timer_elapsed_ms[i] <= 0 && !cfg.timer_running[i] && !cfg.timer_notified[i]) continue;
         long long elapsed_ms = cfg.timer_elapsed_ms[i];

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -20,6 +20,10 @@ inline bool config_write(const Config& c, std::ostream& f) {
         c.pomodoro_long_secs != defaults.pomodoro_long_secs)
         f << std::format("pomodoro_work={}\npomodoro_short={}\npomodoro_long={}\n",
                          c.pomodoro_work_secs, c.pomodoro_short_secs, c.pomodoro_long_secs);
+    if (c.pomodoro_cadence != defaults.pomodoro_cadence)
+        f << std::format("pomodoro_cadence={}\n", c.pomodoro_cadence);
+    if (c.pomodoro_auto_start != defaults.pomodoro_auto_start)
+        f << std::format("pomodoro_auto_start={}\n", c.pomodoro_auto_start ? 1 : 0);
     for (int i = 0; i < c.num_timers; ++i) {
         f << std::format("timer{}={}\n", i, c.timer_secs[i]);
         if (!c.timer_labels[i].empty()) f << std::format("timer{}_label={}\n", i, c.timer_labels[i]);
@@ -114,6 +118,10 @@ inline bool config_read(Config& c, std::istream& f) {
             c.pomodoro_short_secs = clamp_int(val, 60, Config::TIMER_MAX_SECS);
         else if (key == "pomodoro_long")
             c.pomodoro_long_secs = clamp_int(val, 60, Config::TIMER_MAX_SECS);
+        else if (key == "pomodoro_cadence")
+            c.pomodoro_cadence = clamp_int(val, POMODORO_MIN_CADENCE, POMODORO_MAX_CADENCE);
+        else if (key == "pomodoro_auto_start")
+            c.pomodoro_auto_start = val != 0;
         else if (key == "sw_running")
             c.sw_running = val != 0;
         else if (key == "sw_elapsed_ms")
@@ -140,7 +148,7 @@ inline bool config_read(Config& c, std::istream& f) {
                 else if (field == "_pomodoro")
                     c.timer_pomodoro[i] = val != 0;
                 else if (field == "_pomodoro_phase")
-                    c.timer_pomodoro_phase[i] = clamp_int(val, 0, POMODORO_PHASE_COUNT - 1);
+                    c.timer_pomodoro_phase[i] = clamp_int(val, 0, pomodoro_phase_count(POMODORO_MAX_CADENCE) - 1);
                 else if (field == "_pomodoro_work_secs")
                     c.timer_pomodoro_work_secs[i] = std::max(val, 0LL);
             }

--- a/src/painting_timer.hpp
+++ b/src/painting_timer.hpp
@@ -64,7 +64,7 @@ inline void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
         // fontLarge size because field_half > col_gap/2.)
         SelectObject(hdc, ctx.res.fontSm);
         SetTextColor(hdc, th.dim);
-        std::wstring phase_lbl = pomodoro_phase_label(ts.pomodoro_phase);
+        std::wstring phase_lbl = pomodoro_phase_label(ts.pomodoro_phase, ctx.app.pomodoro_cadence);
         if (ts.pomodoro_work_elapsed.count() > 0)
             phase_lbl += L" \u00B7 " + format_worked_time(ts.pomodoro_work_elapsed);
         RECT lr{0, y + m.up_off, cw, y + m.up_off + layout.dpi_scale(20)};

--- a/src/polling.hpp
+++ b/src/polling.hpp
@@ -80,7 +80,8 @@ inline void handle_wm_timer(HWND hwnd, WndState& s) {
             }
             if (ts.pomodoro) {
                 advance_pomodoro_phase(ts, s.app.pomodoro_work_secs,
-                    s.app.pomodoro_short_secs, s.app.pomodoro_long_secs, now);
+                    s.app.pomodoro_short_secs, s.app.pomodoro_long_secs,
+                    s.app.pomodoro_cadence, s.app.pomodoro_auto_start, now);
                 save_config(hwnd, s);
             }
         }

--- a/src/pomodoro.hpp
+++ b/src/pomodoro.hpp
@@ -3,45 +3,39 @@
 #include <string>
 #include "assert.hpp"
 
-// Pomodoro cycle: Work(25m) · Break(5m) × 4, then LongBreak(15m)
-enum class PomodoroPhase : int {
-    Work1       = 0,
-    ShortBreak1 = 1,
-    Work2       = 2,
-    ShortBreak2 = 3,
-    Work3       = 4,
-    ShortBreak3 = 5,
-    Work4       = 6,
-    LongBreak   = 7,
-};
+constexpr int POMODORO_DEFAULT_CADENCE    = 4;
+constexpr int POMODORO_MIN_CADENCE        = 1;
+constexpr int POMODORO_MAX_CADENCE        = 10;
+constexpr int POMODORO_WORK_SECS          = 25 * 60;
+constexpr int POMODORO_SHORT_BREAK_SECS   = 5 * 60;
+constexpr int POMODORO_LONG_BREAK_SECS    = 15 * 60;
 
-constexpr int POMODORO_PHASE_COUNT      = 8;
-constexpr int POMODORO_WORK_SECS        = 25 * 60;
-constexpr int POMODORO_SHORT_BREAK_SECS = 5 * 60;
-constexpr int POMODORO_LONG_BREAK_SECS  = 15 * 60;
+inline constexpr int pomodoro_phase_count(int cadence) { return 2 * cadence; }
 
-static_assert(int(PomodoroPhase::LongBreak) == POMODORO_PHASE_COUNT - 1,
-              "POMODORO_PHASE_COUNT out of sync with PomodoroPhase enum");
+inline bool pomodoro_is_work(int phase) { return phase % 2 == 0; }
 
-inline bool pomodoro_is_work(PomodoroPhase p) { return int(p) % 2 == 0; }
-
-inline PomodoroPhase pomodoro_next_phase(PomodoroPhase p) {
-    return static_cast<PomodoroPhase>((int(p) + 1) % POMODORO_PHASE_COUNT);
+inline bool pomodoro_is_long_break(int phase, int cadence) {
+    return phase == pomodoro_phase_count(cadence) - 1;
 }
 
-inline int pomodoro_phase_secs(PomodoroPhase phase,
+inline int pomodoro_next_phase(int phase, int cadence = POMODORO_DEFAULT_CADENCE) {
+    return (phase + 1) % pomodoro_phase_count(cadence);
+}
+
+inline int pomodoro_phase_secs(int phase,
                                int work_secs  = POMODORO_WORK_SECS,
                                int short_secs = POMODORO_SHORT_BREAK_SECS,
-                               int long_secs  = POMODORO_LONG_BREAK_SECS) {
-    CHRONOS_ASSERT(int(phase) >= 0 && int(phase) < POMODORO_PHASE_COUNT);
+                               int long_secs  = POMODORO_LONG_BREAK_SECS,
+                               int cadence    = POMODORO_DEFAULT_CADENCE) {
+    CHRONOS_ASSERT(phase >= 0 && phase < pomodoro_phase_count(cadence));
     if (pomodoro_is_work(phase)) return work_secs;
-    if (phase == PomodoroPhase::LongBreak) return long_secs;
+    if (pomodoro_is_long_break(phase, cadence)) return long_secs;
     return short_secs;
 }
 
-inline std::wstring pomodoro_phase_label(PomodoroPhase phase) {
-    CHRONOS_ASSERT(int(phase) >= 0 && int(phase) < POMODORO_PHASE_COUNT);
-    if (pomodoro_is_work(phase)) return std::format(L"Work {}/4", int(phase) / 2 + 1);
-    if (phase == PomodoroPhase::LongBreak) return L"Long Break";
+inline std::wstring pomodoro_phase_label(int phase, int cadence = POMODORO_DEFAULT_CADENCE) {
+    CHRONOS_ASSERT(phase >= 0 && phase < pomodoro_phase_count(cadence));
+    if (pomodoro_is_work(phase)) return std::format(L"Work {}/{}", phase / 2 + 1, cadence);
+    if (pomodoro_is_long_break(phase, cadence)) return L"Long Break";
     return L"Short Break";
 }

--- a/src/settings_dialog.hpp
+++ b/src/settings_dialog.hpp
@@ -17,14 +17,17 @@ constexpr int IDC_LBL_LONG     = 306;
 constexpr int IDC_MIN_WORK     = 307;
 constexpr int IDC_MIN_SHORT    = 308;
 constexpr int IDC_MIN_LONG     = 309;
-constexpr int IDC_SET_OK       = 310;
-constexpr int IDC_SET_CANCEL   = 311;
+constexpr int IDC_POMO_CADENCE = 310;
+constexpr int IDC_LBL_CADENCE = 311;
+constexpr int IDC_MIN_CADENCE = 312;
+constexpr int IDC_SET_OK       = 313;
+constexpr int IDC_SET_CANCEL   = 314;
 
 constexpr WORD CLS_BUTTON = 0x0080;
 constexpr WORD CLS_EDIT   = 0x0081;
 constexpr WORD CLS_STATIC = 0x0082;
 
-constexpr short DLG_W = 240, DLG_H = 138;
+constexpr short DLG_W = 240, DLG_H = 156;
 constexpr short SIDEBAR_W = 62;
 constexpr short TITLE_H = 18;
 
@@ -56,7 +59,7 @@ inline void add_item(Buf& b, DWORD style, DWORD exStyle,
     b.push_word(0);
 }
 
-constexpr WORD CTRL_COUNT = 11;
+constexpr WORD CTRL_COUNT = 14;
 
 inline std::vector<WORD> build_template() {
     Buf b;
@@ -98,11 +101,19 @@ inline std::vector<WORD> build_template() {
     add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
              min_x, r2, min_w, row_h, IDC_MIN_LONG, CLS_STATIC, L"min");
 
+    short r3 = y0 + 3 * sp;
+    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
+             lbl_x, r3, lbl_w, row_h, IDC_LBL_CADENCE, CLS_STATIC, L"Long every");
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
+             ed_x, r3, ed_w, row_h, IDC_POMO_CADENCE, CLS_EDIT, L"");
+    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
+             min_x, r3, min_w + 20, row_h, IDC_MIN_CADENCE, CLS_STATIC, L"sessions");
+
     short btn_w = 44, btn_h = 16, btn_gap = 8;
     short content_cx = DLG_W - SIDEBAR_W - 4;
     short total_bw = 2 * btn_w + btn_gap;
     short btn_x0 = SIDEBAR_W + 2 + (content_cx - total_bw) / 2;
-    short btn_y = 120;
+    short btn_y = 138;
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
              btn_x0, btn_y, btn_w, btn_h, IDC_SET_OK, CLS_BUTTON, L"OK");
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
@@ -122,6 +133,7 @@ struct HitRects {
     RECT theme[3];
     RECT clock[4];
     RECT sound;
+    RECT auto_start;
 };
 
 inline HitRects compute_rects(HWND dlg) {
@@ -140,6 +152,7 @@ inline HitRects compute_rects(HWND dlg) {
     h.clock[3] = map_dlu(dlg, 70, 87, 100, 13);
 
     h.sound = map_dlu(dlg, 70, 97, 100, 13);
+    h.auto_start = map_dlu(dlg, 70, 115, 100, 13);
     return h;
 }
 
@@ -149,13 +162,15 @@ struct Params {
     ClockView clock_view;
     bool sound_on_expiry;
     int work_min, short_min, long_min;
+    int cadence;
+    bool auto_start;
     DlgStyle style;
     HitRects rects{};
 };
 
 inline void set_pomo_visible(HWND dlg, bool show) {
     int cmd = show ? SW_SHOW : SW_HIDE;
-    for (int id = IDC_POMO_WORK; id <= IDC_MIN_LONG; ++id) {
+    for (int id = IDC_POMO_WORK; id <= IDC_MIN_CADENCE; ++id) {
         HWND h = GetDlgItem(dlg, id);
         if (h) ShowWindow(h, cmd);
     }
@@ -213,9 +228,11 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         SetDlgItemTextW(dlg, IDC_POMO_WORK,  std::format(L"{}", p->work_min).c_str());
         SetDlgItemTextW(dlg, IDC_POMO_SHORT, std::format(L"{}", p->short_min).c_str());
         SetDlgItemTextW(dlg, IDC_POMO_LONG,  std::format(L"{}", p->long_min).c_str());
+        SetDlgItemTextW(dlg, IDC_POMO_CADENCE, std::format(L"{}", p->cadence).c_str());
         SendDlgItemMessageW(dlg, IDC_POMO_WORK,  EM_SETLIMITTEXT, 4, 0);
         SendDlgItemMessageW(dlg, IDC_POMO_SHORT, EM_SETLIMITTEXT, 4, 0);
         SendDlgItemMessageW(dlg, IDC_POMO_LONG,  EM_SETLIMITTEXT, 4, 0);
+        SendDlgItemMessageW(dlg, IDC_POMO_CADENCE, EM_SETLIMITTEXT, 2, 0);
 
         EnumChildWindows(dlg, [](HWND child, LPARAM param) -> BOOL {
             auto* params = reinterpret_cast<Params*>(param);
@@ -259,7 +276,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         MoveToEx(hdc, sb.right, div_y.bottom, nullptr);
         LineTo(hdc, sb.right, rc.bottom);
 
-        RECT btn_div = {0, 0, 0, 114};
+        RECT btn_div = {0, 0, 0, 132};
         MapDialogRect(dlg, &btn_div);
         MoveToEx(hdc, sb.right, btn_div.bottom, nullptr);
         LineTo(hdc, rc.right, btn_div.bottom);
@@ -285,6 +302,12 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             paint_option_btn(hdc, p->rects.sound,
                             p->sound_on_expiry ? L"Sound: on" : L"Sound: off",
                             p->sound_on_expiry, s);
+        } else if (p->active_tab == TAB_POMODORO) {
+            RECT aslbl = map_dlu(dlg, 70, 105, 80, 8);
+            s.draw_label(hdc, aslbl, L"Auto-start");
+            paint_option_btn(hdc, p->rects.auto_start,
+                            p->auto_start ? L"On" : L"Off",
+                            p->auto_start, s);
         } else if (p->active_tab == TAB_CLOCK) {
             RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
             s.draw_label(hdc, lbl, L"Format");
@@ -393,6 +416,14 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             }
         }
 
+        if (p->active_tab == TAB_POMODORO) {
+            if (PtInRect(&p->rects.auto_start, pt)) {
+                p->auto_start = !p->auto_start;
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
+        }
+
         break;
     }
 
@@ -400,7 +431,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         switch (LOWORD(wp)) {
         case IDC_SET_OK: {
             auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
-            int w = 0, s = 0, l = 0;
+            int w = 0, s = 0, l = 0, cad = 0;
             if (!read_field(dlg, IDC_POMO_WORK, w) ||
                 !read_field(dlg, IDC_POMO_SHORT, s) ||
                 !read_field(dlg, IDC_POMO_LONG, l)) {
@@ -417,7 +448,17 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
                     SetFocus(GetDlgItem(dlg, IDC_POMO_LONG));
                 return TRUE;
             }
+            if (!read_field(dlg, IDC_POMO_CADENCE, cad) ||
+                cad < POMODORO_MIN_CADENCE || cad > POMODORO_MAX_CADENCE) {
+                set_pomo_visible(dlg, true);
+                p->active_tab = TAB_POMODORO;
+                InvalidateRect(dlg, nullptr, TRUE);
+                MessageBeep(MB_ICONASTERISK);
+                SetFocus(GetDlgItem(dlg, IDC_POMO_CADENCE));
+                return TRUE;
+            }
             p->work_min = w; p->short_min = s; p->long_min = l;
+            p->cadence = cad;
             EndDialog(dlg, IDOK);
             return TRUE;
         }
@@ -451,6 +492,8 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
         .work_min  = app.pomodoro_work_secs / 60,
         .short_min = app.pomodoro_short_secs / 60,
         .long_min  = app.pomodoro_long_secs / 60,
+        .cadence   = app.pomodoro_cadence,
+        .auto_start = app.pomodoro_auto_start,
         .style = {.theme = theme, .font = font, .dpi = dpi},
     };
 
@@ -468,5 +511,7 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
     app.pomodoro_work_secs = p.work_min * 60;
     app.pomodoro_short_secs = p.short_min * 60;
     app.pomodoro_long_secs = p.long_min * 60;
+    app.pomodoro_cadence = p.cadence;
+    app.pomodoro_auto_start = p.auto_start;
     return true;
 }

--- a/tests/test_actions_timer.cpp
+++ b/tests/test_actions_timer.cpp
@@ -123,10 +123,10 @@ TEST_CASE("A_TMR_RST_ALL resets Pomodoro state on all timers", "[actions]") {
     App app;
     dispatch_action(app, tmr_act(0, A_TMR_ADD), t0(), {});
     app.timers[0].pomodoro = true;
-    app.timers[0].pomodoro_phase = PomodoroPhase::ShortBreak1;
+    app.timers[0].pomodoro_phase = 1;
     app.timers[0].pomodoro_work_elapsed = seconds{500};
     auto r = dispatch_action(app, A_TMR_RST_ALL, t0(), {});
-    REQUIRE(app.timers[0].pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(app.timers[0].pomodoro_phase == 0);
     REQUIRE(app.timers[0].pomodoro_work_elapsed == seconds{0});
     REQUIRE(r.save_config);
 }

--- a/tests/test_pomodoro.cpp
+++ b/tests/test_pomodoro.cpp
@@ -13,49 +13,49 @@ static sc::time_point t0() { return sc::time_point{}; }
 // ─── pomodoro_phase_secs ──────────────────────────────────────────────────────
 
 TEST_CASE("pomodoro_phase_secs: work phases are 25 minutes", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::Work1) == POMODORO_WORK_SECS);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::Work2) == POMODORO_WORK_SECS);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::Work3) == POMODORO_WORK_SECS);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::Work4) == POMODORO_WORK_SECS);
+    REQUIRE(pomodoro_phase_secs(0) == POMODORO_WORK_SECS);
+    REQUIRE(pomodoro_phase_secs(2) == POMODORO_WORK_SECS);
+    REQUIRE(pomodoro_phase_secs(4) == POMODORO_WORK_SECS);
+    REQUIRE(pomodoro_phase_secs(6) == POMODORO_WORK_SECS);
 }
 
 TEST_CASE("pomodoro_phase_secs: short break phases are 5 minutes", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::ShortBreak1) == POMODORO_SHORT_BREAK_SECS);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::ShortBreak2) == POMODORO_SHORT_BREAK_SECS);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::ShortBreak3) == POMODORO_SHORT_BREAK_SECS);
+    REQUIRE(pomodoro_phase_secs(1) == POMODORO_SHORT_BREAK_SECS);
+    REQUIRE(pomodoro_phase_secs(3) == POMODORO_SHORT_BREAK_SECS);
+    REQUIRE(pomodoro_phase_secs(5) == POMODORO_SHORT_BREAK_SECS);
 }
 
-TEST_CASE("pomodoro_phase_secs: phase LongBreak is a long break", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::LongBreak) == POMODORO_LONG_BREAK_SECS);
+TEST_CASE("pomodoro_phase_secs: last phase is a long break", "[pomodoro]") {
+    REQUIRE(pomodoro_phase_secs(7) == POMODORO_LONG_BREAK_SECS);
 }
 
 TEST_CASE("pomodoro_phase_secs: all valid phases produce expected values", "[pomodoro]") {
-    for (int p = 0; p < POMODORO_PHASE_COUNT; ++p)
-        REQUIRE_NOTHROW(pomodoro_phase_secs(static_cast<PomodoroPhase>(p)));
+    for (int p = 0; p < pomodoro_phase_count(POMODORO_DEFAULT_CADENCE); ++p)
+        REQUIRE_NOTHROW(pomodoro_phase_secs(p));
 }
 
 // ─── pomodoro_phase_label ─────────────────────────────────────────────────────
 
 TEST_CASE("pomodoro_phase_label: work phase labels", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::Work1) == L"Work 1/4");
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::Work2) == L"Work 2/4");
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::Work3) == L"Work 3/4");
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::Work4) == L"Work 4/4");
+    REQUIRE(pomodoro_phase_label(0) == L"Work 1/4");
+    REQUIRE(pomodoro_phase_label(2) == L"Work 2/4");
+    REQUIRE(pomodoro_phase_label(4) == L"Work 3/4");
+    REQUIRE(pomodoro_phase_label(6) == L"Work 4/4");
 }
 
 TEST_CASE("pomodoro_phase_label: short break phases", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::ShortBreak1) == L"Short Break");
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::ShortBreak2) == L"Short Break");
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::ShortBreak3) == L"Short Break");
+    REQUIRE(pomodoro_phase_label(1) == L"Short Break");
+    REQUIRE(pomodoro_phase_label(3) == L"Short Break");
+    REQUIRE(pomodoro_phase_label(5) == L"Short Break");
 }
 
-TEST_CASE("pomodoro_phase_label: LongBreak is Long Break", "[pomodoro]") {
-    REQUIRE(pomodoro_phase_label(PomodoroPhase::LongBreak) == L"Long Break");
+TEST_CASE("pomodoro_phase_label: last phase is Long Break", "[pomodoro]") {
+    REQUIRE(pomodoro_phase_label(7) == L"Long Break");
 }
 
 TEST_CASE("pomodoro_phase_label: all valid phases produce expected labels", "[pomodoro]") {
-    for (int p = 0; p < POMODORO_PHASE_COUNT; ++p)
-        REQUIRE_FALSE(pomodoro_phase_label(static_cast<PomodoroPhase>(p)).empty());
+    for (int p = 0; p < pomodoro_phase_count(POMODORO_DEFAULT_CADENCE); ++p)
+        REQUIRE_FALSE(pomodoro_phase_label(p).empty());
 }
 
 // ─── Config Pomodoro round-trip ───────────────────────────────────────────────
@@ -97,7 +97,7 @@ TEST_CASE("A_TMR_RST on Pomodoro timer resets phase to 0", "[pomodoro][actions]"
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::ShortBreak3;
+    ts.pomodoro_phase = 5;
     ts.dur = seconds{POMODORO_SHORT_BREAK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
@@ -105,9 +105,9 @@ TEST_CASE("A_TMR_RST on Pomodoro timer resets phase to 0", "[pomodoro][actions]"
 
     dispatch_action(app, A_TMR_BASE + A_TMR_RST, t0(), {});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(ts.pomodoro_phase == 0);
     REQUIRE(ts.dur == seconds{POMODORO_WORK_SECS});
-    REQUIRE(ts.label == pomodoro_phase_label(PomodoroPhase::Work1));
+    REQUIRE(ts.label == pomodoro_phase_label(0));
     REQUIRE_FALSE(ts.t.is_running());
 }
 
@@ -133,16 +133,15 @@ TEST_CASE("pomodoro_phase_secs: custom durations used when provided", "[pomodoro
     constexpr int WORK = 50 * 60;
     constexpr int SHORT = 10 * 60;
     constexpr int LONG = 20 * 60;
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::Work1,       WORK, SHORT, LONG) == WORK);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::ShortBreak1, WORK, SHORT, LONG) == SHORT);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::ShortBreak2, WORK, SHORT, LONG) == SHORT);
-    REQUIRE(pomodoro_phase_secs(PomodoroPhase::LongBreak,   WORK, SHORT, LONG) == LONG);
+    REQUIRE(pomodoro_phase_secs(0, WORK, SHORT, LONG) == WORK);
+    REQUIRE(pomodoro_phase_secs(1, WORK, SHORT, LONG) == SHORT);
+    REQUIRE(pomodoro_phase_secs(3, WORK, SHORT, LONG) == SHORT);
+    REQUIRE(pomodoro_phase_secs(7, WORK, SHORT, LONG) == LONG);
 }
 
 TEST_CASE("pomodoro_phase_secs: default args match constants", "[pomodoro]") {
-    for (int p = 0; p < POMODORO_PHASE_COUNT; ++p) {
-        auto phase = static_cast<PomodoroPhase>(p);
-        REQUIRE(pomodoro_phase_secs(phase) == pomodoro_phase_secs(phase, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS));
+    for (int p = 0; p < pomodoro_phase_count(POMODORO_DEFAULT_CADENCE); ++p) {
+        REQUIRE(pomodoro_phase_secs(p) == pomodoro_phase_secs(p, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS));
     }
 }
 
@@ -227,7 +226,7 @@ TEST_CASE("A_TMR_RST on Pomodoro timer resets work elapsed", "[pomodoro][actions
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::ShortBreak2;
+    ts.pomodoro_phase = 3;
     ts.pomodoro_work_elapsed = seconds{75 * 60};
     ts.dur = seconds{POMODORO_SHORT_BREAK_SECS};
     ts.t.reset();
@@ -245,7 +244,7 @@ TEST_CASE("A_TMR_SKIP advances phase and starts next timer", "[pomodoro][actions
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
@@ -253,9 +252,9 @@ TEST_CASE("A_TMR_SKIP advances phase and starts next timer", "[pomodoro][actions
 
     auto r = dispatch_action(app, tmr_act(0, A_TMR_SKIP), t0() + seconds{600}, {});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::ShortBreak1);
+    REQUIRE(ts.pomodoro_phase == 1);
     REQUIRE(ts.dur == seconds{POMODORO_SHORT_BREAK_SECS});
-    REQUIRE(ts.label == pomodoro_phase_label(PomodoroPhase::ShortBreak1));
+    REQUIRE(ts.label == pomodoro_phase_label(1));
     REQUIRE(ts.t.is_running());
     REQUIRE(r.save_config);
 }
@@ -264,7 +263,7 @@ TEST_CASE("A_TMR_SKIP on work phase credits actual elapsed time", "[pomodoro][ac
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.pomodoro_work_elapsed = seconds{0};
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
@@ -280,7 +279,7 @@ TEST_CASE("A_TMR_SKIP on break phase does not credit work time", "[pomodoro][act
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::ShortBreak1;
+    ts.pomodoro_phase = 1;
     ts.pomodoro_work_elapsed = seconds{25 * 60};
     ts.dur = seconds{POMODORO_SHORT_BREAK_SECS};
     ts.t.reset();
@@ -290,7 +289,7 @@ TEST_CASE("A_TMR_SKIP on break phase does not credit work time", "[pomodoro][act
     dispatch_action(app, tmr_act(0, A_TMR_SKIP), t0() + seconds{60}, {});
 
     REQUIRE(ts.pomodoro_work_elapsed == seconds{25 * 60});
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work2);
+    REQUIRE(ts.pomodoro_phase == 2);
 }
 
 TEST_CASE("A_TMR_SKIP is no-op on non-Pomodoro timer", "[pomodoro][actions]") {
@@ -312,7 +311,7 @@ TEST_CASE("A_TMR_SKIP is no-op when timer not touched", "[pomodoro][actions]") {
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
@@ -320,14 +319,14 @@ TEST_CASE("A_TMR_SKIP is no-op when timer not touched", "[pomodoro][actions]") {
     auto r = dispatch_action(app, tmr_act(0, A_TMR_SKIP), t0(), {});
 
     REQUIRE_FALSE(r.save_config);
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(ts.pomodoro_phase == 0);
 }
 
 TEST_CASE("A_TMR_SKIP wraps from LongBreak back to Work1", "[pomodoro][actions]") {
     App app;
     auto& ts = app.timers[0];
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::LongBreak;
+    ts.pomodoro_phase = 7;
     ts.dur = seconds{POMODORO_LONG_BREAK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
@@ -335,9 +334,9 @@ TEST_CASE("A_TMR_SKIP wraps from LongBreak back to Work1", "[pomodoro][actions]"
 
     dispatch_action(app, tmr_act(0, A_TMR_SKIP), t0() + seconds{60}, {});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(ts.pomodoro_phase == 0);
     REQUIRE(ts.dur == seconds{POMODORO_WORK_SECS});
-    REQUIRE(ts.label == pomodoro_phase_label(PomodoroPhase::Work1));
+    REQUIRE(ts.label == pomodoro_phase_label(0));
 }
 
 // ─── advance_pomodoro_phase ──────────────────────────────────────────────────
@@ -345,16 +344,17 @@ TEST_CASE("A_TMR_SKIP wraps from LongBreak back to Work1", "[pomodoro][actions]"
 TEST_CASE("advance: work expires -> short break, work_elapsed increases", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.pomodoro_work_elapsed = seconds{0};
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, t0() + seconds{POMODORO_WORK_SECS});
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                           POMODORO_DEFAULT_CADENCE, true, t0() + seconds{POMODORO_WORK_SECS});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::ShortBreak1);
+    REQUIRE(ts.pomodoro_phase == 1);
     REQUIRE(ts.dur == seconds{POMODORO_SHORT_BREAK_SECS});
     REQUIRE(ts.label == L"Short Break");
     REQUIRE(ts.pomodoro_work_elapsed == seconds{POMODORO_WORK_SECS});
@@ -365,16 +365,17 @@ TEST_CASE("advance: work expires -> short break, work_elapsed increases", "[pomo
 TEST_CASE("advance: short break expires -> next work phase, work_elapsed unchanged", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::ShortBreak1;
+    ts.pomodoro_phase = 1;
     ts.pomodoro_work_elapsed = seconds{POMODORO_WORK_SECS};
     ts.dur = seconds{POMODORO_SHORT_BREAK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, t0() + seconds{POMODORO_SHORT_BREAK_SECS});
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                           POMODORO_DEFAULT_CADENCE, true, t0() + seconds{POMODORO_SHORT_BREAK_SECS});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work2);
+    REQUIRE(ts.pomodoro_phase == 2);
     REQUIRE(ts.dur == seconds{POMODORO_WORK_SECS});
     REQUIRE(ts.label == L"Work 2/4");
     REQUIRE(ts.pomodoro_work_elapsed == seconds{POMODORO_WORK_SECS});
@@ -384,16 +385,17 @@ TEST_CASE("advance: short break expires -> next work phase, work_elapsed unchang
 TEST_CASE("advance: Work4 expires -> long break", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work4;
+    ts.pomodoro_phase = 6;
     ts.pomodoro_work_elapsed = seconds{3 * POMODORO_WORK_SECS};
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, t0() + seconds{POMODORO_WORK_SECS});
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                           POMODORO_DEFAULT_CADENCE, true, t0() + seconds{POMODORO_WORK_SECS});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::LongBreak);
+    REQUIRE(ts.pomodoro_phase == 7);
     REQUIRE(ts.dur == seconds{POMODORO_LONG_BREAK_SECS});
     REQUIRE(ts.label == L"Long Break");
     REQUIRE(ts.pomodoro_work_elapsed == seconds{4 * POMODORO_WORK_SECS});
@@ -402,16 +404,17 @@ TEST_CASE("advance: Work4 expires -> long break", "[pomodoro][advance]") {
 TEST_CASE("advance: long break expires -> wraps to Work1, work_elapsed unchanged", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::LongBreak;
+    ts.pomodoro_phase = 7;
     ts.pomodoro_work_elapsed = seconds{4 * POMODORO_WORK_SECS};
     ts.dur = seconds{POMODORO_LONG_BREAK_SECS};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, t0() + seconds{POMODORO_LONG_BREAK_SECS});
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                           POMODORO_DEFAULT_CADENCE, true, t0() + seconds{POMODORO_LONG_BREAK_SECS});
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(ts.pomodoro_phase == 0);
     REQUIRE(ts.dur == seconds{POMODORO_WORK_SECS});
     REQUIRE(ts.label == L"Work 1/4");
     REQUIRE(ts.pomodoro_work_elapsed == seconds{4 * POMODORO_WORK_SECS});
@@ -425,23 +428,23 @@ TEST_CASE("advance: custom durations flow through correctly", "[pomodoro][advanc
 
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.dur = seconds{WORK};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, WORK, SHORT, LONG, t0() + seconds{WORK});
+    advance_pomodoro_phase(ts, WORK, SHORT, LONG, POMODORO_DEFAULT_CADENCE, true, t0() + seconds{WORK});
 
     REQUIRE(ts.dur == seconds{SHORT});
 
-    ts.pomodoro_phase = PomodoroPhase::Work4;
+    ts.pomodoro_phase = 6;
     ts.dur = seconds{WORK};
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, WORK, SHORT, LONG, t0() + seconds{WORK});
+    advance_pomodoro_phase(ts, WORK, SHORT, LONG, POMODORO_DEFAULT_CADENCE, true, t0() + seconds{WORK});
 
     REQUIRE(ts.dur == seconds{LONG});
     REQUIRE(ts.label == L"Long Break");
@@ -450,14 +453,15 @@ TEST_CASE("advance: custom durations flow through correctly", "[pomodoro][advanc
 TEST_CASE("advance: notified flag is cleared", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.notified = true;
     ts.t.reset();
     ts.t.set(ts.dur);
     ts.t.start(t0());
 
-    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, t0() + seconds{POMODORO_WORK_SECS});
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                           POMODORO_DEFAULT_CADENCE, true, t0() + seconds{POMODORO_WORK_SECS});
 
     REQUIRE_FALSE(ts.notified);
 }
@@ -465,7 +469,7 @@ TEST_CASE("advance: notified flag is cleared", "[pomodoro][advance]") {
 TEST_CASE("advance: full cycle through all 8 phases", "[pomodoro][advance]") {
     TimerSlot ts;
     ts.pomodoro = true;
-    ts.pomodoro_phase = PomodoroPhase::Work1;
+    ts.pomodoro_phase = 0;
     ts.pomodoro_work_elapsed = seconds{0};
     ts.dur = seconds{POMODORO_WORK_SECS};
     ts.t.reset();
@@ -473,12 +477,14 @@ TEST_CASE("advance: full cycle through all 8 phases", "[pomodoro][advance]") {
     ts.t.start(t0());
 
     auto now = t0();
-    for (int i = 0; i < POMODORO_PHASE_COUNT; ++i) {
+    int count = pomodoro_phase_count(POMODORO_DEFAULT_CADENCE);
+    for (int i = 0; i < count; ++i) {
         now += ts.dur;
-        advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS, now);
+        advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS, POMODORO_LONG_BREAK_SECS,
+                               POMODORO_DEFAULT_CADENCE, true, now);
     }
 
-    REQUIRE(ts.pomodoro_phase == PomodoroPhase::Work1);
+    REQUIRE(ts.pomodoro_phase == 0);
     REQUIRE(ts.dur == seconds{POMODORO_WORK_SECS});
     REQUIRE(ts.label == L"Work 1/4");
     REQUIRE(ts.pomodoro_work_elapsed == seconds{4 * POMODORO_WORK_SECS});
@@ -495,4 +501,166 @@ TEST_CASE("Config pomodoro durations written when any differs from default", "[p
     REQUIRE(os.str().find("pomodoro_work=1800") != std::string::npos);
     REQUIRE(os.str().find("pomodoro_short=300") != std::string::npos);
     REQUIRE(os.str().find("pomodoro_long=900") != std::string::npos);
+}
+
+// ─── Configurable cadence ────────────────────────────────────────────────────
+
+TEST_CASE("pomodoro_phase_count reflects cadence", "[pomodoro][cadence]") {
+    REQUIRE(pomodoro_phase_count(1) == 2);
+    REQUIRE(pomodoro_phase_count(4) == 8);
+    REQUIRE(pomodoro_phase_count(6) == 12);
+    REQUIRE(pomodoro_phase_count(10) == 20);
+}
+
+TEST_CASE("cadence 2: two work sessions then long break", "[pomodoro][cadence]") {
+    constexpr int CAD = 2;
+    REQUIRE(pomodoro_phase_label(0, CAD) == L"Work 1/2");
+    REQUIRE(pomodoro_phase_label(1, CAD) == L"Short Break");
+    REQUIRE(pomodoro_phase_label(2, CAD) == L"Work 2/2");
+    REQUIRE(pomodoro_phase_label(3, CAD) == L"Long Break");
+}
+
+TEST_CASE("cadence 1: single work session then long break", "[pomodoro][cadence]") {
+    constexpr int CAD = 1;
+    REQUIRE(pomodoro_phase_count(CAD) == 2);
+    REQUIRE(pomodoro_phase_label(0, CAD) == L"Work 1/1");
+    REQUIRE(pomodoro_phase_label(1, CAD) == L"Long Break");
+    REQUIRE(pomodoro_is_long_break(1, CAD));
+}
+
+TEST_CASE("cadence 6: six work sessions then long break", "[pomodoro][cadence]") {
+    constexpr int CAD = 6;
+    REQUIRE(pomodoro_phase_count(CAD) == 12);
+    REQUIRE(pomodoro_phase_label(10, CAD) == L"Work 6/6");
+    REQUIRE(pomodoro_phase_label(11, CAD) == L"Long Break");
+    REQUIRE(pomodoro_is_long_break(11, CAD));
+    REQUIRE_FALSE(pomodoro_is_long_break(9, CAD));
+}
+
+TEST_CASE("advance with custom cadence cycles correctly", "[pomodoro][cadence][advance]") {
+    constexpr int CAD = 2;
+    TimerSlot ts;
+    ts.pomodoro = true;
+    ts.pomodoro_phase = 0;
+    ts.pomodoro_work_elapsed = seconds{0};
+    ts.dur = seconds{POMODORO_WORK_SECS};
+    ts.t.reset();
+    ts.t.set(ts.dur);
+    ts.t.start(t0());
+
+    auto now = t0();
+    int count = pomodoro_phase_count(CAD);
+    for (int i = 0; i < count; ++i) {
+        now += ts.dur;
+        advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS,
+                               POMODORO_LONG_BREAK_SECS, CAD, true, now);
+    }
+
+    REQUIRE(ts.pomodoro_phase == 0);
+    REQUIRE(ts.label == L"Work 1/2");
+    REQUIRE(ts.pomodoro_work_elapsed == seconds{2 * POMODORO_WORK_SECS});
+}
+
+TEST_CASE("Config cadence round-trip", "[pomodoro][cadence][config]") {
+    Config orig;
+    orig.pomodoro_cadence = 6;
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    Config back;
+    std::istringstream is(os.str());
+    config_read(back, is);
+
+    REQUIRE(back.pomodoro_cadence == 6);
+}
+
+TEST_CASE("Config cadence not written at default", "[pomodoro][cadence][config]") {
+    Config orig;
+    REQUIRE(orig.pomodoro_cadence == POMODORO_DEFAULT_CADENCE);
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    REQUIRE(os.str().find("pomodoro_cadence") == std::string::npos);
+}
+
+TEST_CASE("Config cadence clamped to valid range", "[pomodoro][cadence][config]") {
+    std::istringstream is("pomodoro_cadence=99\n");
+    Config c;
+    config_read(c, is);
+    REQUIRE(c.pomodoro_cadence == POMODORO_MAX_CADENCE);
+
+    std::istringstream is2("pomodoro_cadence=0\n");
+    Config c2;
+    config_read(c2, is2);
+    REQUIRE(c2.pomodoro_cadence == POMODORO_MIN_CADENCE);
+}
+
+// ─── Auto-start toggle ──────────────────────────────────────────────────────
+
+TEST_CASE("advance with auto_start=false does not start timer", "[pomodoro][auto_start][advance]") {
+    TimerSlot ts;
+    ts.pomodoro = true;
+    ts.pomodoro_phase = 0;
+    ts.dur = seconds{POMODORO_WORK_SECS};
+    ts.t.reset();
+    ts.t.set(ts.dur);
+    ts.t.start(t0());
+
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS,
+                           POMODORO_LONG_BREAK_SECS, POMODORO_DEFAULT_CADENCE, false,
+                           t0() + seconds{POMODORO_WORK_SECS});
+
+    REQUIRE(ts.pomodoro_phase == 1);
+    REQUIRE(ts.dur == seconds{POMODORO_SHORT_BREAK_SECS});
+    REQUIRE_FALSE(ts.t.is_running());
+    REQUIRE_FALSE(ts.t.touched());
+}
+
+TEST_CASE("advance with auto_start=true starts timer", "[pomodoro][auto_start][advance]") {
+    TimerSlot ts;
+    ts.pomodoro = true;
+    ts.pomodoro_phase = 0;
+    ts.dur = seconds{POMODORO_WORK_SECS};
+    ts.t.reset();
+    ts.t.set(ts.dur);
+    ts.t.start(t0());
+
+    advance_pomodoro_phase(ts, POMODORO_WORK_SECS, POMODORO_SHORT_BREAK_SECS,
+                           POMODORO_LONG_BREAK_SECS, POMODORO_DEFAULT_CADENCE, true,
+                           t0() + seconds{POMODORO_WORK_SECS});
+
+    REQUIRE(ts.pomodoro_phase == 1);
+    REQUIRE(ts.t.is_running());
+}
+
+TEST_CASE("Config auto_start round-trip", "[pomodoro][auto_start][config]") {
+    Config orig;
+    orig.pomodoro_auto_start = false;
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    Config back;
+    std::istringstream is(os.str());
+    config_read(back, is);
+
+    REQUIRE_FALSE(back.pomodoro_auto_start);
+}
+
+TEST_CASE("Config auto_start not written at default", "[pomodoro][auto_start][config]") {
+    Config orig;
+    REQUIRE(orig.pomodoro_auto_start == true);
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    REQUIRE(os.str().find("pomodoro_auto_start") == std::string::npos);
+}
+
+TEST_CASE("Config auto_start defaults", "[pomodoro][auto_start][config]") {
+    Config c;
+    REQUIRE(c.pomodoro_auto_start == true);
+    REQUIRE(c.pomodoro_cadence == POMODORO_DEFAULT_CADENCE);
 }


### PR DESCRIPTION
## Summary

Closes #268.

- Replace the hardcoded 8-phase (4-work-session) pomodoro cycle with a dynamic cycle driven by a configurable **cadence** (1–10 sessions before long break, default 4)
- Add an **auto-start toggle** — when off, the timer pauses at 0 after each phase and waits for the user to press start instead of automatically beginning the next phase
- Both settings are exposed in the Pomodoro tab of the settings panel and persisted to `config.ini`

## Changes

- `pomodoro.hpp`: Removed hardcoded `PomodoroPhase` enum; all phase functions now accept a `cadence` parameter
- `config.hpp` / `config_serial.hpp` / `config_io.hpp`: Added `pomodoro_cadence` and `pomodoro_auto_start` fields with serialization
- `app.hpp`: Updated `advance_pomodoro_phase()` to accept cadence and auto_start params
- `settings_dialog.hpp`: Added "Long every N sessions" input and "Auto-start: On/Off" toggle to Pomodoro tab
- `actions.hpp` / `polling.hpp` / `painting_timer.hpp`: Pass cadence through all pomodoro call sites
- Tests: Updated all 228 tests (all passing), added new tests for custom cadence and auto-start behavior

## Test plan

- [x] All 228 unit tests pass (including 12 new tests for cadence and auto-start)
- [ ] Verify cadence=2 shows "Work 1/2", "Short Break", "Work 2/2", "Long Break" cycle
- [ ] Verify cadence=1 shows "Work 1/1", "Long Break" cycle
- [ ] Verify auto-start off pauses timer at end of each phase
- [ ] Verify settings persist across app restart

---
_Generated by [Claude Code](https://claude.ai/code/session_014cmUBCDcqnJfKoDRCqR5a3)_