### PR TITLE
fix: replace undeclared PomodoroPhase::Work1 with int literal

### DIFF
--- a/src/input_mouse.hpp
+++ b/src/input_mouse.hpp
@@ -66,9 +66,9 @@ inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPA
                 auto& ts = s.app.timers[idx];
                 if (cmd == CMD_POMODORO) {
                     ts.pomodoro = true;
-                    ts.pomodoro_phase = PomodoroPhase::Work1;
+                    ts.pomodoro_phase = 0;
                     ts.dur = std::chrono::seconds{s.app.pomodoro_work_secs};
-                    ts.label = pomodoro_phase_label(PomodoroPhase::Work1);
+                    ts.label = pomodoro_phase_label(0, s.app.pomodoro_cadence);
                     ts.notified = false;
                     ts.t.reset();
                     ts.t.set(ts.dur);


### PR DESCRIPTION
## Summary\n\n- Fixes Windows CI build failure caused by use of undeclared `PomodoroPhase::Work1` identifier in `input_mouse.hpp`\n- Replaced with plain `int` literal `0` matching the convention used throughout the rest of the codebase (e.g. `actions.hpp`)\n- Also passes `s.app.pomodoro_cadence` to `pomodoro_phase_label()` for correctness\n\nCloses #279, closes #280, closes #281, closes #282\n\nhttps://claude.ai/code/session_01R2MJCBeZsLtRoh9egRzW4K

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2MJCBeZsLtRoh9egRzW4K)_