### PR TITLE
feat: add user-defined custom timer presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Chronos are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.9.0] — 2026-05-12
+
+### Added
+- **Custom timer presets** — define up to 5 personal presets (in minutes) via the new **Timers** tab in the settings panel; presets appear in the right-click timer menu below the built-in durations (#270)
+- Custom presets persisted to `config.ini` (`num_custom_presets`, `custom_preset0`–`custom_preset4`)
+
 ## [1.8.0] — 2026-05-12
 
 ### Added

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -48,6 +48,7 @@ struct App {
     int pomodoro_long_secs = 15 * 60;
     int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
     bool pomodoro_auto_start = true;
+    std::vector<int> custom_preset_secs;
     bool show_help = false;
     bool lap_write_failed = false;
     int blink_act = 0;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -22,6 +22,7 @@ struct Config {
     static constexpr int TIMER_MIN_SECS = 0;
     static constexpr int TIMER_MAX_SECS = 86400;
     static constexpr int MIN_WINDOW_W = 260;
+    static constexpr int MAX_CUSTOM_PRESETS = 5;
     int num_timers = 1;
     std::array<int, MAX_TIMERS> timer_secs{};
     std::array<std::string, MAX_TIMERS> timer_labels{};
@@ -46,5 +47,7 @@ struct Config {
     int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
     bool pomodoro_auto_start = true;
     ClockView clock_view = ClockView::H24_HMS;
+    int num_custom_presets = 0;
+    std::array<int, MAX_CUSTOM_PRESETS> custom_preset_secs{};
     Config() { timer_secs.fill(60); }
 };

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -49,6 +49,9 @@ inline void save_config(HWND hwnd, const WndState& s) {
     cfg.pomodoro_long_secs = s.app.pomodoro_long_secs;
     cfg.pomodoro_cadence = s.app.pomodoro_cadence;
     cfg.pomodoro_auto_start = s.app.pomodoro_auto_start;
+    cfg.num_custom_presets = (int)s.app.custom_preset_secs.size();
+    for (int i = 0; i < cfg.num_custom_presets; ++i)
+        cfg.custom_preset_secs[i] = s.app.custom_preset_secs[i];
     cfg.num_timers = (int)s.app.timers.size();
     auto now_steady = steady_clock::now();
     auto now_wall_ms = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
@@ -122,6 +125,9 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.pomodoro_long_secs = cfg.pomodoro_long_secs;
     s.app.pomodoro_cadence = cfg.pomodoro_cadence;
     s.app.pomodoro_auto_start = cfg.pomodoro_auto_start;
+    s.app.custom_preset_secs.clear();
+    for (int i = 0; i < cfg.num_custom_presets; ++i)
+        s.app.custom_preset_secs.push_back(cfg.custom_preset_secs[i]);
     int n = std::min(cfg.num_timers, Config::MAX_TIMERS);
     s.app.timers.resize(n);
     for (int i = 0; i < n; ++i) {

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -24,6 +24,11 @@ inline bool config_write(const Config& c, std::ostream& f) {
         f << std::format("pomodoro_cadence={}\n", c.pomodoro_cadence);
     if (c.pomodoro_auto_start != defaults.pomodoro_auto_start)
         f << std::format("pomodoro_auto_start={}\n", c.pomodoro_auto_start ? 1 : 0);
+    if (c.num_custom_presets > 0) {
+        f << std::format("num_custom_presets={}\n", c.num_custom_presets);
+        for (int i = 0; i < c.num_custom_presets; ++i)
+            f << std::format("custom_preset{}={}\n", i, c.custom_preset_secs[i]);
+    }
     for (int i = 0; i < c.num_timers; ++i) {
         f << std::format("timer{}={}\n", i, c.timer_secs[i]);
         if (!c.timer_labels[i].empty()) f << std::format("timer{}_label={}\n", i, c.timer_labels[i]);
@@ -91,6 +96,15 @@ inline bool config_read(Config& c, std::istream& f) {
         };
         if (key == "clock_view") {
             c.clock_view = (ClockView)clamp_int(val, 0, CLOCK_VIEW_COUNT - 1);
+        } else if (key == "num_custom_presets") {
+            c.num_custom_presets = clamp_int(val, 0, Config::MAX_CUSTOM_PRESETS);
+        } else if (key.starts_with("custom_preset") && key.size() > 13) {
+            auto idx_str = key.substr(13);
+            int i;
+            auto [ptr, ec2] = std::from_chars(idx_str.data(), idx_str.data() + idx_str.size(), i);
+            if (ec2 == std::errc{} && ptr == idx_str.data() + idx_str.size() &&
+                i >= 0 && i < Config::MAX_CUSTOM_PRESETS)
+                c.custom_preset_secs[i] = clamp_int(val, 1, Config::TIMER_MAX_SECS);
         } else if (key == "show_clk")
             c.show_clk = val != 0;
         else if (key == "show_sw")

--- a/src/input_mouse.hpp
+++ b/src/input_mouse.hpp
@@ -48,8 +48,16 @@ inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPA
         if (idx >= 0 && !s.app.timers[idx].t.touched()) {
             constexpr int CMD_POMODORO = 100;
             constexpr int CMD_POMO_CFG = 101;
+            constexpr int CMD_CUSTOM_BASE = 200;
             HMENU menu = CreatePopupMenu();
             for (int i = 0; i < (int)std::size(TIMER_PRESETS); ++i) AppendMenuW(menu, MF_STRING, 1 + i, TIMER_PRESETS[i].label);
+            if (!s.app.custom_preset_secs.empty()) {
+                AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+                for (int i = 0; i < (int)s.app.custom_preset_secs.size(); ++i) {
+                    auto label = format_preset_label(s.app.custom_preset_secs[i]);
+                    AppendMenuW(menu, MF_STRING, CMD_CUSTOM_BASE + i, label.c_str());
+                }
+            }
             AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
             int pom_min = s.app.pomodoro_work_secs / 60;
             int pom_sec = s.app.pomodoro_work_secs % 60;
@@ -80,6 +88,16 @@ inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPA
                         save_config(hwnd, s);
                         InvalidateRect(hwnd, nullptr, FALSE);
                     }
+                } else if (cmd >= CMD_CUSTOM_BASE &&
+                           cmd < CMD_CUSTOM_BASE + (int)s.app.custom_preset_secs.size()) {
+                    ts.pomodoro = false;
+                    ts.label.clear();
+                    ts.dur = std::chrono::seconds{s.app.custom_preset_secs[cmd - CMD_CUSTOM_BASE]};
+                    ts.notified = false;
+                    ts.t.reset();
+                    ts.t.set(ts.dur);
+                    save_config(hwnd, s);
+                    InvalidateRect(hwnd, nullptr, FALSE);
                 } else {
                     ts.pomodoro = false;
                     ts.label.clear();

--- a/src/settings_dialog.hpp
+++ b/src/settings_dialog.hpp
@@ -22,6 +22,16 @@ constexpr int IDC_LBL_CADENCE = 311;
 constexpr int IDC_MIN_CADENCE = 312;
 constexpr int IDC_SET_OK       = 313;
 constexpr int IDC_SET_CANCEL   = 314;
+constexpr int IDC_PRESET_ED0   = 320;
+constexpr int IDC_PRESET_ED1   = 321;
+constexpr int IDC_PRESET_ED2   = 322;
+constexpr int IDC_PRESET_ED3   = 323;
+constexpr int IDC_PRESET_ED4   = 324;
+constexpr int IDC_PRESET_MIN0  = 325;
+constexpr int IDC_PRESET_MIN1  = 326;
+constexpr int IDC_PRESET_MIN2  = 327;
+constexpr int IDC_PRESET_MIN3  = 328;
+constexpr int IDC_PRESET_MIN4  = 329;
 
 constexpr WORD CLS_BUTTON = 0x0080;
 constexpr WORD CLS_EDIT   = 0x0081;
@@ -34,7 +44,8 @@ constexpr short TITLE_H = 18;
 constexpr int TAB_APPEARANCE = 0;
 constexpr int TAB_CLOCK      = 1;
 constexpr int TAB_POMODORO   = 2;
-constexpr int TAB_COUNT      = 3;
+constexpr int TAB_TIMERS     = 3;
+constexpr int TAB_COUNT      = 4;
 
 struct Buf {
     std::vector<WORD> data;
@@ -59,7 +70,7 @@ inline void add_item(Buf& b, DWORD style, DWORD exStyle,
     b.push_word(0);
 }
 
-constexpr WORD CTRL_COUNT = 14;
+constexpr WORD CTRL_COUNT = 24;
 
 inline std::vector<WORD> build_template() {
     Buf b;
@@ -109,6 +120,21 @@ inline std::vector<WORD> build_template() {
     add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
              min_x, r3, min_w + 20, row_h, IDC_MIN_CADENCE, CLS_STATIC, L"sessions");
 
+    short pr_ed_x = 96, pr_ed_w = 28;
+    short pr_min_x = 128, pr_min_w = 18;
+    short pr_y0 = 40, pr_sp = 16;
+    int pr_edit_ids[] = {IDC_PRESET_ED0, IDC_PRESET_ED1, IDC_PRESET_ED2,
+                         IDC_PRESET_ED3, IDC_PRESET_ED4};
+    int pr_min_ids[] = {IDC_PRESET_MIN0, IDC_PRESET_MIN1, IDC_PRESET_MIN2,
+                        IDC_PRESET_MIN3, IDC_PRESET_MIN4};
+    for (int i = 0; i < 5; ++i) {
+        short py = pr_y0 + (short)(i * pr_sp);
+        add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
+                 pr_ed_x, py, pr_ed_w, row_h, (WORD)pr_edit_ids[i], CLS_EDIT, L"");
+        add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
+                 pr_min_x, py, pr_min_w, row_h, (WORD)pr_min_ids[i], CLS_STATIC, L"min");
+    }
+
     short btn_w = 44, btn_h = 16, btn_gap = 8;
     short content_cx = DLG_W - SIDEBAR_W - 4;
     short total_bw = 2 * btn_w + btn_gap;
@@ -134,6 +160,7 @@ struct HitRects {
     RECT clock[4];
     RECT sound;
     RECT auto_start;
+    RECT preset_row[5];
 };
 
 inline HitRects compute_rects(HWND dlg) {
@@ -141,6 +168,7 @@ inline HitRects compute_rects(HWND dlg) {
     h.sidebar[0] = map_dlu(dlg, 3, 24, 56, 14);
     h.sidebar[1] = map_dlu(dlg, 3, 40, 56, 14);
     h.sidebar[2] = map_dlu(dlg, 3, 56, 56, 14);
+    h.sidebar[3] = map_dlu(dlg, 3, 72, 56, 14);
 
     h.theme[0] = map_dlu(dlg, 70, 42, 54, 13);
     h.theme[1] = map_dlu(dlg, 70, 57, 54, 13);
@@ -164,6 +192,7 @@ struct Params {
     int work_min, short_min, long_min;
     int cadence;
     bool auto_start;
+    int preset_min[5]{};
     DlgStyle style;
     HitRects rects{};
 };
@@ -171,6 +200,16 @@ struct Params {
 inline void set_pomo_visible(HWND dlg, bool show) {
     int cmd = show ? SW_SHOW : SW_HIDE;
     for (int id = IDC_POMO_WORK; id <= IDC_MIN_CADENCE; ++id) {
+        HWND h = GetDlgItem(dlg, id);
+        if (h) ShowWindow(h, cmd);
+    }
+}
+
+inline void set_presets_visible(HWND dlg, bool show) {
+    int cmd = show ? SW_SHOW : SW_HIDE;
+    int ids[] = {IDC_PRESET_ED0, IDC_PRESET_ED1, IDC_PRESET_ED2, IDC_PRESET_ED3, IDC_PRESET_ED4,
+                 IDC_PRESET_MIN0, IDC_PRESET_MIN1, IDC_PRESET_MIN2, IDC_PRESET_MIN3, IDC_PRESET_MIN4};
+    for (int id : ids) {
         HWND h = GetDlgItem(dlg, id);
         if (h) ShowWindow(h, cmd);
     }
@@ -234,6 +273,14 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         SendDlgItemMessageW(dlg, IDC_POMO_LONG,  EM_SETLIMITTEXT, 4, 0);
         SendDlgItemMessageW(dlg, IDC_POMO_CADENCE, EM_SETLIMITTEXT, 2, 0);
 
+        int pr_ids[] = {IDC_PRESET_ED0, IDC_PRESET_ED1, IDC_PRESET_ED2,
+                        IDC_PRESET_ED3, IDC_PRESET_ED4};
+        for (int i = 0; i < 5; ++i) {
+            if (p->preset_min[i] > 0)
+                SetDlgItemTextW(dlg, pr_ids[i], std::format(L"{}", p->preset_min[i]).c_str());
+            SendDlgItemMessageW(dlg, pr_ids[i], EM_SETLIMITTEXT, 4, 0);
+        }
+
         EnumChildWindows(dlg, [](HWND child, LPARAM param) -> BOOL {
             auto* params = reinterpret_cast<Params*>(param);
             SendMessageW(child, WM_SETFONT, (WPARAM)params->style.font, FALSE);
@@ -241,6 +288,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         }, (LPARAM)p);
 
         set_pomo_visible(dlg, false);
+        set_presets_visible(dlg, false);
         return FALSE;
     }
 
@@ -284,7 +332,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         SelectObject(hdc, old_pen);
         DeleteObject(div_pen);
 
-        const wchar_t* tab_names[] = {L"Appearance", L"Clock", L"Pomodoro"};
+        const wchar_t* tab_names[] = {L"Appearance", L"Clock", L"Pomodoro", L"Timers"};
         for (int i = 0; i < TAB_COUNT; ++i)
             paint_option_btn(hdc, p->rects.sidebar[i], tab_names[i],
                             i == p->active_tab, s);
@@ -317,6 +365,14 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             for (int i = 0; i < 4; ++i)
                 paint_option_btn(hdc, p->rects.clock[i], names[i],
                                 (int)p->clock_view == i, s);
+        } else if (p->active_tab == TAB_TIMERS) {
+            RECT lbl = map_dlu(dlg, 70, 28, 100, 12);
+            s.draw_label(hdc, lbl, L"Custom presets");
+            for (int i = 0; i < 5; ++i) {
+                RECT num = map_dlu(dlg, 76, (short)(40 + i * 16), 16, 12);
+                auto txt = std::format(L"{}.", i + 1);
+                s.draw_label(hdc, num, txt.c_str());
+            }
         }
 
         return 1;
@@ -384,8 +440,10 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         for (int i = 0; i < TAB_COUNT; ++i) {
             if (PtInRect(&p->rects.sidebar[i], pt) && i != p->active_tab) {
                 set_pomo_visible(dlg, false);
+                set_presets_visible(dlg, false);
                 p->active_tab = i;
                 set_pomo_visible(dlg, i == TAB_POMODORO);
+                set_presets_visible(dlg, i == TAB_TIMERS);
                 InvalidateRect(dlg, nullptr, TRUE);
                 return TRUE;
             }
@@ -459,6 +517,21 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             }
             p->work_min = w; p->short_min = s; p->long_min = l;
             p->cadence = cad;
+            {
+                int pr_ids[] = {IDC_PRESET_ED0, IDC_PRESET_ED1, IDC_PRESET_ED2,
+                                IDC_PRESET_ED3, IDC_PRESET_ED4};
+                for (int i = 0; i < 5; ++i) {
+                    wchar_t buf[8] = {};
+                    GetDlgItemTextW(dlg, pr_ids[i], buf, 7);
+                    if (buf[0] == L'\0') {
+                        p->preset_min[i] = 0;
+                        continue;
+                    }
+                    wchar_t* end = nullptr;
+                    long v = std::wcstol(buf, &end, 10);
+                    p->preset_min[i] = (v >= 1 && v <= 1440) ? (int)v : 0;
+                }
+            }
             EndDialog(dlg, IDOK);
             return TRUE;
         }
@@ -494,8 +567,11 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
         .long_min  = app.pomodoro_long_secs / 60,
         .cadence   = app.pomodoro_cadence,
         .auto_start = app.pomodoro_auto_start,
+        .preset_min = {},
         .style = {.theme = theme, .font = font, .dpi = dpi},
     };
+    for (int i = 0; i < (int)app.custom_preset_secs.size() && i < 5; ++i)
+        p.preset_min[i] = app.custom_preset_secs[i] / 60;
 
     auto tmpl = build_template();
     HINSTANCE hInst = (HINSTANCE)GetWindowLongPtrW(parent, GWLP_HINSTANCE);
@@ -513,5 +589,9 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
     app.pomodoro_long_secs = p.long_min * 60;
     app.pomodoro_cadence = p.cadence;
     app.pomodoro_auto_start = p.auto_start;
+    app.custom_preset_secs.clear();
+    for (int i = 0; i < 5; ++i)
+        if (p.preset_min[i] > 0)
+            app.custom_preset_secs.push_back(p.preset_min[i] * 60);
     return true;
 }

--- a/src/timer_presets.hpp
+++ b/src/timer_presets.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <format>
+#include <string>
 
 struct TimerPreset {
     int secs;
@@ -11,3 +13,13 @@ inline constexpr TimerPreset TIMER_PRESETS[] = {
     { 1200, L"20:00"},    { 1500, L"25:00"},  { 1800, L"30:00"},
     { 2700, L"45:00"},    { 3600, L"1:00:00"},
 };
+
+inline std::wstring format_preset_label(int secs) {
+    int h = secs / 3600;
+    int m = (secs / 60) % 60;
+    int s = secs % 60;
+    if (h > 0)
+        return s > 0 ? std::format(L"{}:{:02}:{:02}", h, m, s)
+                     : std::format(L"{}:{:02}:00", h, m);
+    return s > 0 ? std::format(L"{}:{:02}", m, s) : std::format(L"{}:00", m);
+}

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -397,3 +397,59 @@ TEST_CASE("Config whitespace around equals is ignored", "[config]") {
     REQUIRE(c.timer_secs[0] == 60);  // default unchanged, line skipped
     REQUIRE(c.show_clk);             // default unchanged, line skipped
 }
+
+TEST_CASE("Config custom presets round-trip", "[config]") {
+    Config orig;
+    orig.num_custom_presets = 3;
+    orig.custom_preset_secs[0] = 420;
+    orig.custom_preset_secs[1] = 900;
+    orig.custom_preset_secs[2] = 2700;
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    Config back;
+    std::istringstream is(os.str());
+    config_read(back, is);
+
+    REQUIRE(back.num_custom_presets == 3);
+    REQUIRE(back.custom_preset_secs[0] == 420);
+    REQUIRE(back.custom_preset_secs[1] == 900);
+    REQUIRE(back.custom_preset_secs[2] == 2700);
+}
+
+TEST_CASE("Config custom presets not written when empty", "[config]") {
+    Config orig;
+    std::ostringstream os;
+    config_write(orig, os);
+    REQUIRE(os.str().find("custom_preset") == std::string::npos);
+    REQUIRE(os.str().find("num_custom_presets") == std::string::npos);
+}
+
+TEST_CASE("Config custom presets count clamped", "[config]") {
+    std::istringstream is("num_custom_presets=99\n");
+    Config c;
+    config_read(c, is);
+    REQUIRE(c.num_custom_presets <= Config::MAX_CUSTOM_PRESETS);
+}
+
+TEST_CASE("Config custom preset values clamped", "[config]") {
+    std::istringstream is("num_custom_presets=1\ncustom_preset0=100000\n");
+    Config c;
+    config_read(c, is);
+    REQUIRE(c.custom_preset_secs[0] == Config::TIMER_MAX_SECS);
+}
+
+TEST_CASE("Config custom preset index out of range ignored", "[config]") {
+    std::istringstream is("num_custom_presets=1\ncustom_preset9=300\n");
+    Config c;
+    config_read(c, is);
+    REQUIRE(c.custom_preset_secs[0] == 0);
+}
+
+TEST_CASE("Config custom presets defaults to zero", "[config]") {
+    Config c;
+    REQUIRE(c.num_custom_presets == 0);
+    for (int i = 0; i < Config::MAX_CUSTOM_PRESETS; ++i)
+        REQUIRE(c.custom_preset_secs[i] == 0);
+}

--- a/tests/test_formatting.cpp
+++ b/tests/test_formatting.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include "../src/formatting.hpp"
+#include "../src/timer_presets.hpp"
 
 using namespace std::chrono;
 using steady_duration = steady_clock::duration;
@@ -179,4 +180,26 @@ TEST_CASE("format_tray_title: multi-timer slot 1", "[formatting]") {
 
 TEST_CASE("format_tray_title: multi-timer slot 3", "[formatting]") {
     REQUIRE(format_tray_title(2, 3) == L"Timer 3 expired");
+}
+
+// ── format_preset_label ──────────────────────────────────────────────────
+
+TEST_CASE("format_preset_label: exact minutes", "[formatting]") {
+    REQUIRE(format_preset_label(60) == L"1:00");
+    REQUIRE(format_preset_label(300) == L"5:00");
+    REQUIRE(format_preset_label(2700) == L"45:00");
+}
+
+TEST_CASE("format_preset_label: minutes and seconds", "[formatting]") {
+    REQUIRE(format_preset_label(90) == L"1:30");
+    REQUIRE(format_preset_label(450) == L"7:30");
+}
+
+TEST_CASE("format_preset_label: hours", "[formatting]") {
+    REQUIRE(format_preset_label(3600) == L"1:00:00");
+    REQUIRE(format_preset_label(5400) == L"1:30:00");
+}
+
+TEST_CASE("format_preset_label: hours with seconds", "[formatting]") {
+    REQUIRE(format_preset_label(3661) == L"1:01:01");
 }


### PR DESCRIPTION
## Summary

- Add up to 5 user-defined custom timer presets, editable from a new **Timers** tab in the settings panel
- Custom presets appear in the right-click timer menu below the built-in durations, separated by a divider
- All presets persisted to `config.ini` (`num_custom_presets`, `custom_preset0`–`custom_preset4`)

Closes #270

## Test plan

- [x] All 238 tests pass (228 existing + 10 new)
- [x] Config round-trip serialization for custom presets
- [x] Clamping/validation of preset count and values
- [x] `format_preset_label` formatting for minutes, hours, and mixed durations
- [x] Debug build passes

https://claude.ai/code/session_01StgzexREj7cG3LWLyE2cE7

---
_Generated by [Claude Code](https://claude.ai/code/session_01StgzexREj7cG3LWLyE2cE7)_