### PR TITLE
feat: add analog clock view with configurable appearance (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to Chronos are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.10.0] — 2026-05-12
+
+### Added
+- **Analog clock view** — fifth `ClockView` option drawn entirely with GDI: outer circle, hour/minute tick marks, hour/minute/second hands, and centre dot (#271)
+- Analog clock uses a taller layout (`BASE_ANALOG_CLK_H = 120`); window height adjusts automatically when cycling to/from Analog
+- Configurable analog appearance: hand colors, hand lengths (% of radius), hand thickness, tick lengths, show/hide minute ticks, hour labels (None / Sparse / Full)
+- Analog options surfaced in **Clock** tab of the settings panel when Analog format is selected
+- All analog style fields persisted to `config.ini` (prefixed `analog_*`); defaults derive from the active theme for a clean look out of the box
+- Analog clock accessible via click-to-cycle on the clock area or the Clock tab format selector in settings
+
 ## [1.9.0] — 2026-05-12
 
 ### Added

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -189,10 +189,14 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         r.apply_theme = true;
         r.save_config = true;
         break;
-    case A_CLK_CYCLE:
+    case A_CLK_CYCLE: {
+        auto old_view = app.clock_view;
         app.clock_view = (ClockView)(((int)app.clock_view + 1) % CLOCK_VIEW_COUNT);
+        if (old_view == ClockView::Analog || app.clock_view == ClockView::Analog)
+            r.resize = true;
         r.save_config = true;
         break;
+    }
     case A_SETTINGS:
         r.open_settings = true;
         break;

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -43,6 +43,7 @@ struct App {
     bool sound_on_expiry = true;
     ThemeMode theme_mode = ThemeMode::Auto;
     ClockView clock_view = ClockView::H24_HMS;
+    AnalogClockStyle analog_style;
     int pomodoro_work_secs = 25 * 60;
     int pomodoro_short_secs = 5 * 60;
     int pomodoro_long_secs = 15 * 60;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -5,10 +5,30 @@
 #include "pomodoro.hpp"
 
 enum class ThemeMode { Auto = 0, Dark = 1, Light = 2 };
-enum class ClockView { H24_HMS = 0, H24_HM = 1, H12_HMS = 2, H12_HM = 3 };
-inline constexpr int CLOCK_VIEW_COUNT = 4;
-static_assert((int)ClockView::H12_HM == CLOCK_VIEW_COUNT - 1,
+enum class ClockView { H24_HMS = 0, H24_HM = 1, H12_HMS = 2, H12_HM = 3, Analog = 4 };
+inline constexpr int CLOCK_VIEW_COUNT = 5;
+static_assert((int)ClockView::Analog == CLOCK_VIEW_COUNT - 1,
               "CLOCK_VIEW_COUNT out of sync with ClockView enum");
+
+enum class HourLabels { None = 0, Sparse = 1, Full = 2 };
+
+struct AnalogClockStyle {
+    int hour_color = -1;
+    int minute_color = -1;
+    int second_color = -1;
+    int face_color = -1;
+    int tick_color = -1;
+    int hour_len_pct = 60;
+    int minute_len_pct = 80;
+    int second_len_pct = 90;
+    int hour_thickness = 4;
+    int minute_thickness = 2;
+    int second_thickness = 1;
+    int hour_tick_pct = 12;
+    int minute_tick_pct = 5;
+    bool show_minute_ticks = true;
+    HourLabels hour_labels = HourLabels::Sparse;
+};
 
 struct Config {
     bool show_clk = true;
@@ -47,6 +67,7 @@ struct Config {
     int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
     bool pomodoro_auto_start = true;
     ClockView clock_view = ClockView::H24_HMS;
+    AnalogClockStyle analog_style;
     int num_custom_presets = 0;
     std::array<int, MAX_CUSTOM_PRESETS> custom_preset_secs{};
     Config() { timer_secs.fill(60); }

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -44,6 +44,7 @@ inline void save_config(HWND hwnd, const WndState& s) {
     cfg.topmost = s.app.topmost;
     cfg.sound_on_expiry = s.app.sound_on_expiry;
     cfg.theme_mode = s.app.theme_mode;
+    cfg.analog_style = s.app.analog_style;
     cfg.pomodoro_work_secs = s.app.pomodoro_work_secs;
     cfg.pomodoro_short_secs = s.app.pomodoro_short_secs;
     cfg.pomodoro_long_secs = s.app.pomodoro_long_secs;
@@ -120,6 +121,7 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.topmost = cfg.topmost;
     s.app.sound_on_expiry = cfg.sound_on_expiry;
     s.app.theme_mode = cfg.theme_mode;
+    s.app.analog_style = cfg.analog_style;
     s.app.pomodoro_work_secs = cfg.pomodoro_work_secs;
     s.app.pomodoro_short_secs = cfg.pomodoro_short_secs;
     s.app.pomodoro_long_secs = cfg.pomodoro_long_secs;

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -24,6 +24,25 @@ inline bool config_write(const Config& c, std::ostream& f) {
         f << std::format("pomodoro_cadence={}\n", c.pomodoro_cadence);
     if (c.pomodoro_auto_start != defaults.pomodoro_auto_start)
         f << std::format("pomodoro_auto_start={}\n", c.pomodoro_auto_start ? 1 : 0);
+    {
+        const auto& a = c.analog_style;
+        AnalogClockStyle def;
+        if (a.hour_color != def.hour_color) f << std::format("analog_hour_color={}\n", a.hour_color);
+        if (a.minute_color != def.minute_color) f << std::format("analog_minute_color={}\n", a.minute_color);
+        if (a.second_color != def.second_color) f << std::format("analog_second_color={}\n", a.second_color);
+        if (a.face_color != def.face_color) f << std::format("analog_face_color={}\n", a.face_color);
+        if (a.tick_color != def.tick_color) f << std::format("analog_tick_color={}\n", a.tick_color);
+        if (a.hour_len_pct != def.hour_len_pct) f << std::format("analog_hour_len={}\n", a.hour_len_pct);
+        if (a.minute_len_pct != def.minute_len_pct) f << std::format("analog_minute_len={}\n", a.minute_len_pct);
+        if (a.second_len_pct != def.second_len_pct) f << std::format("analog_second_len={}\n", a.second_len_pct);
+        if (a.hour_thickness != def.hour_thickness) f << std::format("analog_hour_thick={}\n", a.hour_thickness);
+        if (a.minute_thickness != def.minute_thickness) f << std::format("analog_minute_thick={}\n", a.minute_thickness);
+        if (a.second_thickness != def.second_thickness) f << std::format("analog_second_thick={}\n", a.second_thickness);
+        if (a.hour_tick_pct != def.hour_tick_pct) f << std::format("analog_hour_tick={}\n", a.hour_tick_pct);
+        if (a.minute_tick_pct != def.minute_tick_pct) f << std::format("analog_minute_tick={}\n", a.minute_tick_pct);
+        if (a.show_minute_ticks != def.show_minute_ticks) f << std::format("analog_show_min_ticks={}\n", a.show_minute_ticks ? 1 : 0);
+        if (a.hour_labels != def.hour_labels) f << std::format("analog_hour_labels={}\n", (int)a.hour_labels);
+    }
     if (c.num_custom_presets > 0) {
         f << std::format("num_custom_presets={}\n", c.num_custom_presets);
         for (int i = 0; i < c.num_custom_presets; ++i)
@@ -136,6 +155,21 @@ inline bool config_read(Config& c, std::istream& f) {
             c.pomodoro_cadence = clamp_int(val, POMODORO_MIN_CADENCE, POMODORO_MAX_CADENCE);
         else if (key == "pomodoro_auto_start")
             c.pomodoro_auto_start = val != 0;
+        else if (key == "analog_hour_color") c.analog_style.hour_color = (int)val;
+        else if (key == "analog_minute_color") c.analog_style.minute_color = (int)val;
+        else if (key == "analog_second_color") c.analog_style.second_color = (int)val;
+        else if (key == "analog_face_color") c.analog_style.face_color = (int)val;
+        else if (key == "analog_tick_color") c.analog_style.tick_color = (int)val;
+        else if (key == "analog_hour_len") c.analog_style.hour_len_pct = clamp_int(val, 40, 80);
+        else if (key == "analog_minute_len") c.analog_style.minute_len_pct = clamp_int(val, 60, 95);
+        else if (key == "analog_second_len") c.analog_style.second_len_pct = clamp_int(val, 70, 98);
+        else if (key == "analog_hour_thick") c.analog_style.hour_thickness = clamp_int(val, 1, 6);
+        else if (key == "analog_minute_thick") c.analog_style.minute_thickness = clamp_int(val, 1, 4);
+        else if (key == "analog_second_thick") c.analog_style.second_thickness = clamp_int(val, 1, 3);
+        else if (key == "analog_hour_tick") c.analog_style.hour_tick_pct = clamp_int(val, 5, 20);
+        else if (key == "analog_minute_tick") c.analog_style.minute_tick_pct = clamp_int(val, 2, 10);
+        else if (key == "analog_show_min_ticks") c.analog_style.show_minute_ticks = val != 0;
+        else if (key == "analog_hour_labels") c.analog_style.hour_labels = (HourLabels)clamp_int(val, 0, 2);
         else if (key == "sw_running")
             c.sw_running = val != 0;
         else if (key == "sw_elapsed_ms")

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -9,6 +9,7 @@ inline LayoutState layout_state(const WndState& s) {
         .show_sw = s.app.show_sw,
         .show_tmr = s.app.show_tmr,
         .timer_count = (int)s.app.timers.size(),
+        .clock_view = s.app.clock_view,
     };
 }
 

--- a/src/input_core.hpp
+++ b/src/input_core.hpp
@@ -57,8 +57,10 @@ inline void handle(HWND hwnd, int act, WndState& s) {
     if (r.apply_theme) apply_theme(hwnd, s);
     if (r.open_settings) {
         auto old_theme = s.app.theme_mode;
+        auto old_clock = s.app.clock_view;
         if (show_settings_dialog(hwnd, s.app, (HFONT)s.fontSm.h, s.active_theme, s.layout.dpi)) {
             if (s.app.theme_mode != old_theme) apply_theme(hwnd, s);
+            if (s.app.clock_view != old_clock) resize_window(hwnd, s);
             save_config(hwnd, s);
         }
     }

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include "assert.hpp"
+#include "config.hpp"
 
 constexpr int STANDARD_DPI = 96;
 
 struct Layout {
     static constexpr int BASE_BAR_H  = 36;
     static constexpr int BASE_CLK_H  = 62;
+    static constexpr int BASE_ANALOG_CLK_H = 120;
     static constexpr int BASE_SW_H   = 116;
     static constexpr int BASE_TMR_H  = 114;
     static constexpr int BASE_BTN_H  = 28;
@@ -18,6 +20,7 @@ struct Layout {
 
     int bar_h   = BASE_BAR_H;
     int clk_h   = BASE_CLK_H;
+    int analog_clk_h = BASE_ANALOG_CLK_H;
     int sw_h    = BASE_SW_H;
     int tmr_h   = BASE_TMR_H;
     int btn_h   = BASE_BTN_H;
@@ -43,6 +46,7 @@ struct Layout {
         dpi = new_dpi;
         bar_h   = dpi_scale(BASE_BAR_H);
         clk_h   = dpi_scale(BASE_CLK_H);
+        analog_clk_h = dpi_scale(BASE_ANALOG_CLK_H);
         sw_h    = dpi_scale(BASE_SW_H);
         tmr_h   = dpi_scale(BASE_TMR_H);
         btn_h   = dpi_scale(BASE_BTN_H);
@@ -60,6 +64,7 @@ struct LayoutState {
     bool show_sw = true;
     bool show_tmr = true;
     int timer_count = 1;
+    ClockView clock_view = ClockView::H24_HMS;
 };
 
 struct TimerMetrics {
@@ -86,9 +91,13 @@ struct TimerMetrics {
     }
 };
 
+inline int effective_clk_h(const Layout& layout, ClockView view) {
+    return view == ClockView::Analog ? layout.analog_clk_h : layout.clk_h;
+}
+
 inline int client_height_for(const Layout& layout, const LayoutState& state) {
     int h = layout.bar_h;
-    if (state.show_clk) h += layout.clk_h;
+    if (state.show_clk) h += effective_clk_h(layout, state.clock_view);
     if (state.show_sw) h += layout.sw_h;
     if (state.show_tmr) h += state.timer_count * layout.tmr_h;
     return h;
@@ -97,7 +106,7 @@ inline int client_height_for(const Layout& layout, const LayoutState& state) {
 inline int timer_index_at_y(const Layout& layout, const LayoutState& state, int y) {
     if (!state.show_tmr) return -1;
     int top = layout.bar_h;
-    if (state.show_clk) top += layout.clk_h;
+    if (state.show_clk) top += effective_clk_h(layout, state.clock_view);
     if (state.show_sw) top += layout.sw_h;
     if (y < top) return -1;
     int idx = (y - top) / layout.tmr_h;

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -12,6 +12,7 @@
 #include "formatting.hpp"
 #include "layout.hpp"
 #include "paint_ctx.hpp"
+#include "painting_analog.hpp"
 #include "painting_timer.hpp"
 #include "theme.hpp"
 
@@ -41,6 +42,15 @@ inline int paint_clock(HDC hdc, int cw, int y, PaintCtx& ctx) {
     divider(hdc, y, cw, ctx);
     SYSTEMTIME st;
     GetLocalTime(&st);
+
+    if (ctx.app.clock_view == ClockView::Analog) {
+        RECT area{0, y, cw, y + layout.analog_clk_h};
+        draw_analog_clock(hdc, area, ctx.app.analog_style, ctx.theme,
+                          ctx.res.fontSm, layout.dpi, st.wHour, st.wMinute, st.wSecond);
+        ctx.btns.push_back({area, A_CLK_CYCLE});
+        return y + layout.analog_clk_h;
+    }
+
     std::wstring buf;
     switch (ctx.app.clock_view) {
     case ClockView::H24_HMS:

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include <windows.h>
+#include <cmath>
+#include "config.hpp"
+#include "gdi.hpp"
+#include "layout.hpp"
+#include "theme.hpp"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct AnalogResolvedColors {
+    COLORREF hour;
+    COLORREF minute;
+    COLORREF second;
+    COLORREF face;
+    COLORREF tick;
+};
+
+inline AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style,
+                                                   const Theme& theme) {
+    return {
+        .hour   = style.hour_color >= 0 ? (COLORREF)style.hour_color : theme.text,
+        .minute = style.minute_color >= 0 ? (COLORREF)style.minute_color : theme.text,
+        .second = style.second_color >= 0 ? (COLORREF)style.second_color : theme.dim,
+        .face   = style.face_color >= 0 ? (COLORREF)style.face_color : theme.divider,
+        .tick   = style.tick_color >= 0 ? (COLORREF)style.tick_color : theme.dim,
+    };
+}
+
+inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
+                               const Theme& theme, HFONT font, int dpi,
+                               int hour, int minute, int second) {
+    auto colors = resolve_analog_colors(style, theme);
+
+    int cx = (area.left + area.right) / 2;
+    int cy = (area.top + area.bottom) / 2;
+    int w = area.right - area.left;
+    int h = area.bottom - area.top;
+    int radius = (w < h ? w : h) / 2 - dpi * 6 / STANDARD_DPI;
+    if (radius < 10) return;
+
+    auto dpi_px = [&](int base) { return base * dpi / STANDARD_DPI; };
+
+    auto angle_rad = [](double units, double total) {
+        return (units / total) * 2.0 * M_PI - M_PI / 2.0;
+    };
+
+    auto line_from_center = [&](double angle, int len, COLORREF color, int thickness) {
+        GdiObj pen{CreatePen(PS_SOLID, dpi_px(thickness), color)};
+        auto* old_pen = (HPEN)SelectObject(hdc, pen.h);
+        int ex = cx + (int)(std::cos(angle) * len);
+        int ey = cy + (int)(std::sin(angle) * len);
+        MoveToEx(hdc, cx, cy, nullptr);
+        LineTo(hdc, ex, ey);
+        SelectObject(hdc, old_pen);
+    };
+
+    {
+        GdiObj face_pen{CreatePen(PS_SOLID, dpi_px(1), colors.face)};
+        HBRUSH null_brush = (HBRUSH)GetStockObject(NULL_BRUSH);
+        auto* old_pen = (HPEN)SelectObject(hdc, face_pen.h);
+        auto* old_brush = (HBRUSH)SelectObject(hdc, null_brush);
+        Ellipse(hdc, cx - radius, cy - radius, cx + radius, cy + radius);
+        SelectObject(hdc, old_pen);
+        SelectObject(hdc, old_brush);
+    }
+
+    for (int i = 0; i < 60; ++i) {
+        bool is_hour_mark = (i % 5 == 0);
+        if (!is_hour_mark && !style.show_minute_ticks) continue;
+        double a = angle_rad(i, 60.0);
+        int tick_pct = is_hour_mark ? style.hour_tick_pct : style.minute_tick_pct;
+        int outer = radius - dpi_px(1);
+        int inner = radius - radius * tick_pct / 100;
+        int thickness = is_hour_mark ? dpi_px(2) : dpi_px(1);
+        GdiObj tick_pen{CreatePen(PS_SOLID, thickness, colors.tick)};
+        auto* old_pen = (HPEN)SelectObject(hdc, tick_pen.h);
+        int ox = cx + (int)(std::cos(a) * outer);
+        int oy = cy + (int)(std::sin(a) * outer);
+        int ix = cx + (int)(std::cos(a) * inner);
+        int iy = cy + (int)(std::sin(a) * inner);
+        MoveToEx(hdc, ox, oy, nullptr);
+        LineTo(hdc, ix, iy);
+        SelectObject(hdc, old_pen);
+    }
+
+    if (style.hour_labels != HourLabels::None) {
+        SetBkMode(hdc, TRANSPARENT);
+        SetTextColor(hdc, colors.tick);
+        int label_font_h = -MulDiv(7, dpi, 72);
+        GdiObj label_font{CreateFontW(label_font_h, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+                                       DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                                       CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"Segoe UI")};
+        auto* old_font = (HFONT)SelectObject(hdc, label_font.h);
+        int label_r = radius - radius * style.hour_tick_pct / 100 - dpi_px(6);
+        for (int i = 1; i <= 12; ++i) {
+            if (style.hour_labels == HourLabels::Sparse && i != 12 && i != 3 && i != 6 && i != 9)
+                continue;
+            double a = angle_rad(i, 12.0);
+            int lx = cx + (int)(std::cos(a) * label_r);
+            int ly = cy + (int)(std::sin(a) * label_r);
+            wchar_t buf[4];
+            wsprintfW(buf, L"%d", i);
+            RECT lr = {lx - dpi_px(8), ly - dpi_px(6), lx + dpi_px(8), ly + dpi_px(6)};
+            DrawTextW(hdc, buf, -1, &lr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        }
+        SelectObject(hdc, old_font);
+    }
+
+    double hour_angle = angle_rad(hour % 12 + minute / 60.0 + second / 3600.0, 12.0);
+    int hour_len = radius * style.hour_len_pct / 100;
+    line_from_center(hour_angle, hour_len, colors.hour, style.hour_thickness);
+
+    double min_angle = angle_rad(minute + second / 60.0, 60.0);
+    int min_len = radius * style.minute_len_pct / 100;
+    line_from_center(min_angle, min_len, colors.minute, style.minute_thickness);
+
+    double sec_angle = angle_rad(second, 60.0);
+    int sec_len = radius * style.second_len_pct / 100;
+    line_from_center(sec_angle, sec_len, colors.second, style.second_thickness);
+
+    {
+        int dot_r = dpi_px(3);
+        GdiObj dot_brush{CreateSolidBrush(colors.hour)};
+        GdiObj dot_pen{CreatePen(PS_NULL, 0, 0)};
+        auto* old_brush = (HBRUSH)SelectObject(hdc, dot_brush.h);
+        auto* old_pen = (HPEN)SelectObject(hdc, dot_pen.h);
+        Ellipse(hdc, cx - dot_r, cy - dot_r, cx + dot_r, cy + dot_r);
+        SelectObject(hdc, old_brush);
+        SelectObject(hdc, old_pen);
+    }
+}

--- a/src/settings_dialog.hpp
+++ b/src/settings_dialog.hpp
@@ -157,10 +157,12 @@ inline RECT map_dlu(HWND dlg, short x, short y, short cx, short cy) {
 struct HitRects {
     RECT sidebar[TAB_COUNT];
     RECT theme[3];
-    RECT clock[4];
+    RECT clock[CLOCK_VIEW_COUNT];
     RECT sound;
     RECT auto_start;
     RECT preset_row[5];
+    RECT analog_min_ticks;
+    RECT analog_labels[3];
 };
 
 inline HitRects compute_rects(HWND dlg) {
@@ -174,10 +176,16 @@ inline HitRects compute_rects(HWND dlg) {
     h.theme[1] = map_dlu(dlg, 70, 57, 54, 13);
     h.theme[2] = map_dlu(dlg, 70, 72, 54, 13);
 
-    h.clock[0] = map_dlu(dlg, 70, 42, 100, 13);
-    h.clock[1] = map_dlu(dlg, 70, 57, 100, 13);
-    h.clock[2] = map_dlu(dlg, 70, 72, 100, 13);
-    h.clock[3] = map_dlu(dlg, 70, 87, 100, 13);
+    h.clock[0] = map_dlu(dlg, 70, 42, 100, 12);
+    h.clock[1] = map_dlu(dlg, 70, 55, 100, 12);
+    h.clock[2] = map_dlu(dlg, 70, 68, 100, 12);
+    h.clock[3] = map_dlu(dlg, 70, 81, 100, 12);
+    h.clock[4] = map_dlu(dlg, 70, 94, 100, 12);
+
+    h.analog_min_ticks = map_dlu(dlg, 70, 118, 80, 12);
+    h.analog_labels[0] = map_dlu(dlg, 70, 136, 34, 12);
+    h.analog_labels[1] = map_dlu(dlg, 106, 136, 34, 12);
+    h.analog_labels[2] = map_dlu(dlg, 142, 136, 34, 12);
 
     h.sound = map_dlu(dlg, 70, 97, 100, 13);
     h.auto_start = map_dlu(dlg, 70, 115, 100, 13);
@@ -188,6 +196,7 @@ struct Params {
     int active_tab = TAB_APPEARANCE;
     ThemeMode theme_mode;
     ClockView clock_view;
+    AnalogClockStyle analog_style;
     bool sound_on_expiry;
     int work_min, short_min, long_min;
     int cadence;
@@ -360,11 +369,25 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
             s.draw_label(hdc, lbl, L"Format");
             const wchar_t* names[] = {
-                L"24h + seconds", L"24h", L"12h + seconds", L"12h"
+                L"24h + seconds", L"24h", L"12h + seconds", L"12h", L"Analog"
             };
-            for (int i = 0; i < 4; ++i)
+            for (int i = 0; i < CLOCK_VIEW_COUNT; ++i)
                 paint_option_btn(hdc, p->rects.clock[i], names[i],
                                 (int)p->clock_view == i, s);
+
+            if (p->clock_view == ClockView::Analog) {
+                RECT aslbl = map_dlu(dlg, 70, 108, 90, 10);
+                s.draw_label(hdc, aslbl, L"Analog options");
+                paint_option_btn(hdc, p->rects.analog_min_ticks,
+                                p->analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
+                                p->analog_style.show_minute_ticks, s);
+                RECT hrlbl = map_dlu(dlg, 70, 128, 90, 8);
+                s.draw_label(hdc, hrlbl, L"Hour labels");
+                const wchar_t* lbl_names[] = {L"None", L"Sparse", L"Full"};
+                for (int i = 0; i < 3; ++i)
+                    paint_option_btn(hdc, p->rects.analog_labels[i], lbl_names[i],
+                                    (int)p->analog_style.hour_labels == i, s);
+            }
         } else if (p->active_tab == TAB_TIMERS) {
             RECT lbl = map_dlu(dlg, 70, 28, 100, 12);
             s.draw_label(hdc, lbl, L"Custom presets");
@@ -465,11 +488,25 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         }
 
         if (p->active_tab == TAB_CLOCK) {
-            for (int i = 0; i < 4; ++i) {
+            for (int i = 0; i < CLOCK_VIEW_COUNT; ++i) {
                 if (PtInRect(&p->rects.clock[i], pt)) {
                     p->clock_view = (ClockView)i;
                     InvalidateRect(dlg, nullptr, TRUE);
                     return TRUE;
+                }
+            }
+            if (p->clock_view == ClockView::Analog) {
+                if (PtInRect(&p->rects.analog_min_ticks, pt)) {
+                    p->analog_style.show_minute_ticks = !p->analog_style.show_minute_ticks;
+                    InvalidateRect(dlg, nullptr, TRUE);
+                    return TRUE;
+                }
+                for (int i = 0; i < 3; ++i) {
+                    if (PtInRect(&p->rects.analog_labels[i], pt)) {
+                        p->analog_style.hour_labels = (HourLabels)i;
+                        InvalidateRect(dlg, nullptr, TRUE);
+                        return TRUE;
+                    }
                 }
             }
         }
@@ -561,6 +598,7 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
         .active_tab = TAB_APPEARANCE,
         .theme_mode = app.theme_mode,
         .clock_view = app.clock_view,
+        .analog_style = app.analog_style,
         .sound_on_expiry = app.sound_on_expiry,
         .work_min  = app.pomodoro_work_secs / 60,
         .short_min = app.pomodoro_short_secs / 60,
@@ -583,6 +621,7 @@ inline bool show_settings_dialog(HWND parent, App& app, HFONT font,
     if (result != IDOK) return false;
     app.theme_mode = p.theme_mode;
     app.clock_view = p.clock_view;
+    app.analog_style = p.analog_style;
     app.sound_on_expiry = p.sound_on_expiry;
     app.pomodoro_work_secs = p.work_min * 60;
     app.pomodoro_short_secs = p.short_min * 60;

--- a/tests/test_actions_dispatch.cpp
+++ b/tests/test_actions_dispatch.cpp
@@ -137,11 +137,17 @@ TEST_CASE("A_CLK_CYCLE cycles through all clock views", "[actions]") {
     REQUIRE(r3.save_config);
 
     auto r4 = dispatch_action(app, A_CLK_CYCLE, t0(), {});
-    REQUIRE(app.clock_view == ClockView::H24_HMS);
+    REQUIRE(app.clock_view == ClockView::Analog);
     REQUIRE(r4.save_config);
+    REQUIRE(r4.resize);
+
+    auto r5 = dispatch_action(app, A_CLK_CYCLE, t0(), {});
+    REQUIRE(app.clock_view == ClockView::H24_HMS);
+    REQUIRE(r5.save_config);
+    REQUIRE(r5.resize);
 }
 
-TEST_CASE("A_CLK_CYCLE does not set resize or apply_theme", "[actions]") {
+TEST_CASE("A_CLK_CYCLE does not set resize between digital views", "[actions]") {
     App app;
     auto r = dispatch_action(app, A_CLK_CYCLE, t0(), {});
     REQUIRE_FALSE(r.resize);

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -194,7 +194,7 @@ TEST_CASE("Config theme round-trip", "[config]") {
 }
 
 TEST_CASE("Config clock_view round-trip", "[config]") {
-    for (auto view : {ClockView::H24_HMS, ClockView::H24_HM, ClockView::H12_HMS, ClockView::H12_HM}) {
+    for (auto view : {ClockView::H24_HMS, ClockView::H24_HM, ClockView::H12_HMS, ClockView::H12_HM, ClockView::Analog}) {
         Config orig;
         orig.clock_view = view;
         std::ostringstream os;
@@ -452,4 +452,79 @@ TEST_CASE("Config custom presets defaults to zero", "[config]") {
     REQUIRE(c.num_custom_presets == 0);
     for (int i = 0; i < Config::MAX_CUSTOM_PRESETS; ++i)
         REQUIRE(c.custom_preset_secs[i] == 0);
+}
+
+TEST_CASE("Config analog style defaults", "[config]") {
+    AnalogClockStyle s;
+    REQUIRE(s.hour_color == -1);
+    REQUIRE(s.minute_color == -1);
+    REQUIRE(s.second_color == -1);
+    REQUIRE(s.face_color == -1);
+    REQUIRE(s.tick_color == -1);
+    REQUIRE(s.hour_len_pct == 60);
+    REQUIRE(s.minute_len_pct == 80);
+    REQUIRE(s.second_len_pct == 90);
+    REQUIRE(s.hour_thickness == 4);
+    REQUIRE(s.minute_thickness == 2);
+    REQUIRE(s.second_thickness == 1);
+    REQUIRE(s.show_minute_ticks);
+    REQUIRE(s.hour_labels == HourLabels::Sparse);
+}
+
+TEST_CASE("Config analog style round-trip", "[config]") {
+    Config orig;
+    orig.analog_style.hour_color = 0xFF0000;
+    orig.analog_style.minute_color = 0x00FF00;
+    orig.analog_style.second_color = 0x0000FF;
+    orig.analog_style.face_color = 0xAAAAAA;
+    orig.analog_style.tick_color = 0x555555;
+    orig.analog_style.hour_len_pct = 55;
+    orig.analog_style.minute_len_pct = 85;
+    orig.analog_style.second_len_pct = 95;
+    orig.analog_style.hour_thickness = 5;
+    orig.analog_style.minute_thickness = 3;
+    orig.analog_style.second_thickness = 2;
+    orig.analog_style.hour_tick_pct = 15;
+    orig.analog_style.minute_tick_pct = 7;
+    orig.analog_style.show_minute_ticks = false;
+    orig.analog_style.hour_labels = HourLabels::Full;
+
+    std::ostringstream os;
+    config_write(orig, os);
+
+    Config back;
+    std::istringstream is(os.str());
+    config_read(back, is);
+
+    REQUIRE(back.analog_style.hour_color == 0xFF0000);
+    REQUIRE(back.analog_style.minute_color == 0x00FF00);
+    REQUIRE(back.analog_style.second_color == 0x0000FF);
+    REQUIRE(back.analog_style.face_color == 0xAAAAAA);
+    REQUIRE(back.analog_style.tick_color == 0x555555);
+    REQUIRE(back.analog_style.hour_len_pct == 55);
+    REQUIRE(back.analog_style.minute_len_pct == 85);
+    REQUIRE(back.analog_style.second_len_pct == 95);
+    REQUIRE(back.analog_style.hour_thickness == 5);
+    REQUIRE(back.analog_style.minute_thickness == 3);
+    REQUIRE(back.analog_style.second_thickness == 2);
+    REQUIRE(back.analog_style.hour_tick_pct == 15);
+    REQUIRE(back.analog_style.minute_tick_pct == 7);
+    REQUIRE_FALSE(back.analog_style.show_minute_ticks);
+    REQUIRE(back.analog_style.hour_labels == HourLabels::Full);
+}
+
+TEST_CASE("Config analog style not written when defaults", "[config]") {
+    Config orig;
+    std::ostringstream os;
+    config_write(orig, os);
+    REQUIRE(os.str().find("analog_") == std::string::npos);
+}
+
+TEST_CASE("Config analog style values clamped", "[config]") {
+    std::istringstream is("analog_hour_len=100\nanalog_minute_thick=10\nanalog_hour_labels=5\n");
+    Config c;
+    config_read(c, is);
+    REQUIRE(c.analog_style.hour_len_pct == 80);
+    REQUIRE(c.analog_style.minute_thickness == 4);
+    REQUIRE(c.analog_style.hour_labels == HourLabels::Full);
 }

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -31,6 +31,7 @@ TEST_CASE("Layout update_for_dpi: standard 96 DPI", "[layout]") {
     l.update_for_dpi(96);
     REQUIRE(l.bar_h == 36);
     REQUIRE(l.clk_h == 62);
+    REQUIRE(l.analog_clk_h == 120);
     REQUIRE(l.sw_h == 116);
     REQUIRE(l.tmr_h == 114);
     REQUIRE(l.btn_h == 28);
@@ -41,6 +42,7 @@ TEST_CASE("Layout update_for_dpi: 192 DPI doubles values", "[layout]") {
     l.update_for_dpi(192);
     REQUIRE(l.bar_h == 72);
     REQUIRE(l.clk_h == 124);
+    REQUIRE(l.analog_clk_h == 240);
     REQUIRE(l.sw_h == 232);
     REQUIRE(l.tmr_h == 228);
     REQUIRE(l.btn_h == 56);
@@ -118,4 +120,35 @@ TEST_CASE("timer_index_at_y: click below all timers", "[layout]") {
     LayoutState s{false, false, true, 1};
     int bottom = l.bar_h + l.tmr_h;
     REQUIRE(timer_index_at_y(l, s, bottom + 10) == -1);
+}
+
+TEST_CASE("client_height_for: analog clock uses taller height", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    LayoutState digital{true, false, false, 1, ClockView::H24_HMS};
+    LayoutState analog{true, false, false, 1, ClockView::Analog};
+    int h_digital = client_height_for(l, digital);
+    int h_analog = client_height_for(l, analog);
+    REQUIRE(h_digital == 36 + 62);
+    REQUIRE(h_analog == 36 + 120);
+    REQUIRE(h_analog > h_digital);
+}
+
+TEST_CASE("effective_clk_h returns correct height per view", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    REQUIRE(effective_clk_h(l, ClockView::H24_HMS) == 62);
+    REQUIRE(effective_clk_h(l, ClockView::H24_HM) == 62);
+    REQUIRE(effective_clk_h(l, ClockView::H12_HMS) == 62);
+    REQUIRE(effective_clk_h(l, ClockView::H12_HM) == 62);
+    REQUIRE(effective_clk_h(l, ClockView::Analog) == 120);
+}
+
+TEST_CASE("timer_index_at_y accounts for analog clock height", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    LayoutState s{true, false, true, 1, ClockView::Analog};
+    int top = l.bar_h + l.analog_clk_h;
+    REQUIRE(timer_index_at_y(l, s, top + 1) == 0);
+    REQUIRE(timer_index_at_y(l, s, top - 1) == -1);
 }


### PR DESCRIPTION
## Summary

- Adds **Analog** as a fifth `ClockView` option, drawn entirely with GDI (outer circle, hour/minute tick marks, three hands, centre dot)
- Window height adjusts automatically when cycling to/from Analog (`BASE_ANALOG_CLK_H = 120`)
- Full configurable style: hand colors, lengths, thickness, tick lengths, show/hide minute ticks, hour labels (None / Sparse / Full)
- Analog options surfaced in **Clock** tab of settings panel when Analog format is selected
- All style fields persisted to `config.ini` with `analog_*` prefix; defaults derive from active theme

## Test plan

- [x] All 245 tests pass (7 new tests added)
- [x] Clock view cycling test updated for 5 views including resize on analog transitions
- [x] Config round-trip tests for all analog style fields
- [x] Layout height tests for analog vs digital clock views
- [x] Debug build passes
- [x] Clamping tests for out-of-range analog config values

Closes #271

---
_Generated by [Claude Code](https://claude.ai/code/session_014G3wnTTsCSYc4y494zk5o2)_