### PR TITLE
fix: remove unused font param; add CI coverage reporting

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -16,4 +16,4 @@ runs:
         echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ inputs.version }} main" \
           | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y clang-${{ inputs.version }} cmake ninja-build
+        sudo apt-get install -y clang-${{ inputs.version }} llvm-${{ inputs.version }} cmake ninja-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
+          set -o pipefail
           llvm-profdata-19 merge -sparse build/chronos-*.profraw -o build/merged.profdata
           llvm-cov-19 report build/chronos_tests -instr-profile=build/merged.profdata -ignore-filename-regex='_deps|tests/' 2>&1 | tee coverage-report.txt
           echo "--- Coverage Summary ---"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,60 @@ jobs:
         with:
           job-name: test-linux-debug (Debug)
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-llvm
+
+      - name: Configure
+        run: |
+          set -o pipefail
+          cmake --preset coverage -DCMAKE_CXX_COMPILER=clang++-19 2>&1 | tee configure-output.txt
+
+      - name: Build
+        run: |
+          set -o pipefail
+          cmake --build build 2>&1 | tee build-output.txt
+
+      - name: Test
+        run: |
+          set -o pipefail
+          cd build && LLVM_PROFILE_FILE="chronos-%p.profraw" ctest --output-on-failure 2>&1 | tee ../test-output.txt
+
+      - name: Generate coverage report
+        run: |
+          llvm-profdata-19 merge -sparse build/chronos-*.profraw -o build/merged.profdata
+          llvm-cov-19 report build/chronos_tests -instr-profile=build/merged.profdata -ignore-filename-regex='_deps|tests/' 2>&1 | tee coverage-report.txt
+          echo "--- Coverage Summary ---"
+          tail -1 coverage-report.txt
+          llvm-cov-19 export build/chronos_tests -instr-profile=build/merged.profdata -format=lcov -ignore-filename-regex='_deps|tests/' > coverage.lcov
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          retention-days: 30
+          path: |
+            coverage-report.txt
+            coverage.lcov
+          if-no-files-found: ignore
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-logs
+          retention-days: 7
+          path: |
+            configure-output.txt
+            build-output.txt
+            test-output.txt
+          if-no-files-found: ignore
+
   sanitizer-check:
     runs-on: ubuntu-latest
     steps:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,6 +41,15 @@
                 "BUILD_TESTS": "ON",
                 "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer"
             }
+        },
+        {
+            "name": "coverage",
+            "inherits": "base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_TESTS": "ON",
+                "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping"
+            }
         }
     ]
 }

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -46,7 +46,7 @@ inline int paint_clock(HDC hdc, int cw, int y, PaintCtx& ctx) {
     if (ctx.app.clock_view == ClockView::Analog) {
         RECT area{0, y, cw, y + layout.analog_clk_h};
         draw_analog_clock(hdc, area, ctx.app.analog_style, ctx.theme,
-                          ctx.res.fontSm, layout.dpi, st.wHour, st.wMinute, st.wSecond);
+                          layout.dpi, st.wHour, st.wMinute, st.wSecond);
         ctx.btns.push_back({area, A_CLK_CYCLE});
         return y + layout.analog_clk_h;
     }

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -30,7 +30,7 @@ inline AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style,
 }
 
 inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
-                               const Theme& theme, HFONT font, int dpi,
+                               const Theme& theme, int dpi,
                                int hour, int minute, int second) {
     auto colors = resolve_analog_colors(style, theme);
 


### PR DESCRIPTION
## Summary

- **Fix Windows CI build failure**: Remove unused `font` parameter from `draw_analog_clock()` in `painting_analog.hpp` — the function creates its own label font internally, so the passed-in font was never used. This caused `-Werror,-Wunused-parameter` on Windows/Clang. Fixes #289, #288, #287.
- **Add code coverage reporting** (closes #228): New `coverage` CMake preset with `-fprofile-instr-generate -fcoverage-mapping`, a `coverage` CI job using `llvm-cov-19`, and LCOV export uploaded as a build artifact. No hard threshold enforced — visibility only, per the issue spec.

### Changes
- `src/painting_analog.hpp`: Remove unused `HFONT font` parameter from `draw_analog_clock()`
- `src/painting.hpp`: Update call site to match new signature
- `CMakePresets.json`: Add `coverage` preset (Debug + instrumentation flags)
- `.github/actions/setup-llvm/action.yml`: Install `llvm-19` package (provides `llvm-profdata-19`, `llvm-cov-19`)
- `.github/workflows/build.yml`: Add `coverage` job that builds, tests, merges profiles, generates text + LCOV reports

## Test plan
- [ ] Windows CI job passes (the unused-parameter error is resolved)
- [ ] Linux CI jobs pass (no regressions)
- [ ] New coverage job runs successfully and uploads `coverage-report.txt` + `coverage.lcov` artifacts

https://claude.ai/code/session_017J2xJVKrPUfdAX1jdixncu

---
_Generated by [Claude Code](https://claude.ai/code/session_017J2xJVKrPUfdAX1jdixncu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now installs matching LLVM and Clang toolsets and build tools.
  * Added an automated coverage job that builds with coverage instrumentation, runs tests, merges profiles, and uploads LCOV/text reports and logs.
  * Added a coverage configure preset to enable coverage instrumentation.

* **Refactor**
  * Simplified internal analog clock drawing interface by removing an unused font parameter.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/290)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->