### PR TITLE
fix: remove unused font param from draw_analog_clock (Windows CI)

### DIFF
--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -46,7 +46,7 @@ inline int paint_clock(HDC hdc, int cw, int y, PaintCtx& ctx) {
     if (ctx.app.clock_view == ClockView::Analog) {
         RECT area{0, y, cw, y + layout.analog_clk_h};
         draw_analog_clock(hdc, area, ctx.app.analog_style, ctx.theme,
-                          ctx.res.fontSm, layout.dpi, st.wHour, st.wMinute, st.wSecond);
+                          layout.dpi, st.wHour, st.wMinute, st.wSecond);
         ctx.btns.push_back({area, A_CLK_CYCLE});
         return y + layout.analog_clk_h;
     }

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -30,7 +30,7 @@ inline AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style,
 }
 
 inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
-                               const Theme& theme, HFONT font, int dpi,
+                               const Theme& theme, int dpi,
                                int hour, int minute, int second) {
     auto colors = resolve_analog_colors(style, theme);
 


### PR DESCRIPTION
## Summary

- Removes the unused `font` parameter from `draw_analog_clock` in `painting_analog.hpp`
- Updates the single call site in `painting.hpp` to match
- The parameter was never used — the function already creates its own label font via `CreateFontW` internally
- Fixes the Windows CI failure reported in issue #289 (`-Werror,-Wunused-parameter` on clang)

## Test plan

- [ ] Windows CI `build-and-test` passes (the unused-parameter error is gone)
- [ ] Linux CI passes (no functional change, just signature cleanup)

https://claude.ai/code/session_01CTDN8nz4oyrz6Kr4Akp2BT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTDN8nz4oyrz6Kr4Akp2BT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal analog clock rendering function parameters for improved code maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/291)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->