### PR TITLE
fix: light/dark mode buttons select the wrong theme (#292)

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -185,7 +185,7 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         if (!app.sw.laps().empty()) r.copy_laps = true;
         break;
     case A_THEME:
-        app.theme_mode = (ThemeMode)(((int)app.theme_mode + 1) % 3);
+        app.theme_mode = (ThemeMode)(((int)app.theme_mode + 1) % THEME_MODE_COUNT);
         r.apply_theme = true;
         r.save_config = true;
         break;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -5,6 +5,9 @@
 #include "pomodoro.hpp"
 
 enum class ThemeMode { Auto = 0, Light = 1, Dark = 2 };
+inline constexpr int THEME_MODE_COUNT = 3;
+static_assert((int)ThemeMode::Dark == THEME_MODE_COUNT - 1,
+              "THEME_MODE_COUNT out of sync with ThemeMode enum");
 enum class ClockView { H24_HMS = 0, H24_HM = 1, H12_HMS = 2, H12_HM = 3, Analog = 4 };
 inline constexpr int CLOCK_VIEW_COUNT = 5;
 static_assert((int)ClockView::Analog == CLOCK_VIEW_COUNT - 1,

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -4,7 +4,7 @@
 
 #include "pomodoro.hpp"
 
-enum class ThemeMode { Auto = 0, Dark = 1, Light = 2 };
+enum class ThemeMode { Auto = 0, Light = 1, Dark = 2 };
 enum class ClockView { H24_HMS = 0, H24_HM = 1, H12_HMS = 2, H12_HM = 3, Analog = 4 };
 inline constexpr int CLOCK_VIEW_COUNT = 5;
 static_assert((int)ClockView::Analog == CLOCK_VIEW_COUNT - 1,

--- a/tests/test_actions_dispatch.cpp
+++ b/tests/test_actions_dispatch.cpp
@@ -94,12 +94,12 @@ TEST_CASE("A_THEME cycles theme mode and signals apply_theme", "[actions]") {
     REQUIRE(app.theme_mode == ThemeMode::Auto);
 
     auto r1 = dispatch_action(app, A_THEME, t0(), {});
-    REQUIRE(app.theme_mode == ThemeMode::Dark);
+    REQUIRE(app.theme_mode == ThemeMode::Light);
     REQUIRE(r1.apply_theme);
     REQUIRE(r1.save_config);
 
     auto r2 = dispatch_action(app, A_THEME, t0(), {});
-    REQUIRE(app.theme_mode == ThemeMode::Light);
+    REQUIRE(app.theme_mode == ThemeMode::Dark);
     REQUIRE(r2.apply_theme);
     REQUIRE(r2.save_config);
 


### PR DESCRIPTION
## Summary

- `ThemeMode` enum had `Dark=1, Light=2` but the settings UI listed the buttons as `Auto / Light / Dark` (light before dark), so clicking "Light" applied the dark theme and vice versa.
- Fixed by reordering the enum to `Auto=0, Light=1, Dark=2` to match the UI display order.
- The `A_THEME` cycle action (increments enum value mod 3) now cycles `Auto → Light → Dark → Auto`, which is the natural user-facing order. Updated the corresponding test.
- Config serialization uses string tokens (`"dark"`/`"light"`) so no saved configs are affected.

## Test plan

- [ ] Open Settings → Appearance, click "Light" — app should turn light
- [ ] Click "Dark" — app should turn dark
- [ ] Click "Auto" — app should follow system preference
- [ ] Right-click cycle action (A_THEME) should step through Auto → Light → Dark → Auto
- [ ] All 622 unit test assertions pass (`chronos_tests`)

Fixes #292

https://claude.ai/code/session_01Dv5bZZXoTMMgmqD5UpGax4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv5bZZXoTMMgmqD5UpGax4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed theme switching so toggling reliably applies and saves the correct light and dark themes.

* **Tests**
  * Updated automated tests to reflect the corrected theme toggle sequence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/295)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->