### PR TITLE
Add rich analog clock styling, AA rendering and settings UI controls

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -19,8 +19,13 @@ struct AnalogClockStyle {
     int hour_color = -1;
     int minute_color = -1;
     int second_color = -1;
-    int face_color = -1;
+    int face_color = -1; // legacy outline color, kept for existing configs
     int tick_color = -1;
+    int background_color = -1;
+    int face_fill_color = -1;
+    int face_outline_color = -1;
+    int hour_label_color = -1;
+    int center_dot_color = -1;
     int hour_len_pct = 60;
     int minute_len_pct = 80;
     int second_len_pct = 90;
@@ -29,6 +34,13 @@ struct AnalogClockStyle {
     int second_thickness = 1;
     int hour_tick_pct = 12;
     int minute_tick_pct = 5;
+    int center_dot_size = 3;
+    int hour_opacity_pct = 100;
+    int minute_opacity_pct = 100;
+    int second_opacity_pct = 100;
+    int tick_opacity_pct = 100;
+    int face_opacity_pct = 100;
+    int radius_pct = 100;
     bool show_minute_ticks = true;
     HourLabels hour_labels = HourLabels::Sparse;
 };

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -32,6 +32,11 @@ inline bool config_write(const Config& c, std::ostream& f) {
         if (a.second_color != def.second_color) f << std::format("analog_second_color={}\n", a.second_color);
         if (a.face_color != def.face_color) f << std::format("analog_face_color={}\n", a.face_color);
         if (a.tick_color != def.tick_color) f << std::format("analog_tick_color={}\n", a.tick_color);
+        if (a.background_color != def.background_color) f << std::format("analog_background_color={}\n", a.background_color);
+        if (a.face_fill_color != def.face_fill_color) f << std::format("analog_face_fill_color={}\n", a.face_fill_color);
+        if (a.face_outline_color != def.face_outline_color) f << std::format("analog_face_outline_color={}\n", a.face_outline_color);
+        if (a.hour_label_color != def.hour_label_color) f << std::format("analog_hour_label_color={}\n", a.hour_label_color);
+        if (a.center_dot_color != def.center_dot_color) f << std::format("analog_center_dot_color={}\n", a.center_dot_color);
         if (a.hour_len_pct != def.hour_len_pct) f << std::format("analog_hour_len={}\n", a.hour_len_pct);
         if (a.minute_len_pct != def.minute_len_pct) f << std::format("analog_minute_len={}\n", a.minute_len_pct);
         if (a.second_len_pct != def.second_len_pct) f << std::format("analog_second_len={}\n", a.second_len_pct);
@@ -40,6 +45,13 @@ inline bool config_write(const Config& c, std::ostream& f) {
         if (a.second_thickness != def.second_thickness) f << std::format("analog_second_thick={}\n", a.second_thickness);
         if (a.hour_tick_pct != def.hour_tick_pct) f << std::format("analog_hour_tick={}\n", a.hour_tick_pct);
         if (a.minute_tick_pct != def.minute_tick_pct) f << std::format("analog_minute_tick={}\n", a.minute_tick_pct);
+        if (a.center_dot_size != def.center_dot_size) f << std::format("analog_center_dot_size={}\n", a.center_dot_size);
+        if (a.hour_opacity_pct != def.hour_opacity_pct) f << std::format("analog_hour_opacity={}\n", a.hour_opacity_pct);
+        if (a.minute_opacity_pct != def.minute_opacity_pct) f << std::format("analog_minute_opacity={}\n", a.minute_opacity_pct);
+        if (a.second_opacity_pct != def.second_opacity_pct) f << std::format("analog_second_opacity={}\n", a.second_opacity_pct);
+        if (a.tick_opacity_pct != def.tick_opacity_pct) f << std::format("analog_tick_opacity={}\n", a.tick_opacity_pct);
+        if (a.face_opacity_pct != def.face_opacity_pct) f << std::format("analog_face_opacity={}\n", a.face_opacity_pct);
+        if (a.radius_pct != def.radius_pct) f << std::format("analog_radius={}\n", a.radius_pct);
         if (a.show_minute_ticks != def.show_minute_ticks) f << std::format("analog_show_min_ticks={}\n", a.show_minute_ticks ? 1 : 0);
         if (a.hour_labels != def.hour_labels) f << std::format("analog_hour_labels={}\n", (int)a.hour_labels);
     }
@@ -160,6 +172,11 @@ inline bool config_read(Config& c, std::istream& f) {
         else if (key == "analog_second_color") c.analog_style.second_color = (int)val;
         else if (key == "analog_face_color") c.analog_style.face_color = (int)val;
         else if (key == "analog_tick_color") c.analog_style.tick_color = (int)val;
+        else if (key == "analog_background_color") c.analog_style.background_color = (int)val;
+        else if (key == "analog_face_fill_color") c.analog_style.face_fill_color = (int)val;
+        else if (key == "analog_face_outline_color") c.analog_style.face_outline_color = (int)val;
+        else if (key == "analog_hour_label_color") c.analog_style.hour_label_color = (int)val;
+        else if (key == "analog_center_dot_color") c.analog_style.center_dot_color = (int)val;
         else if (key == "analog_hour_len") c.analog_style.hour_len_pct = clamp_int(val, 40, 80);
         else if (key == "analog_minute_len") c.analog_style.minute_len_pct = clamp_int(val, 60, 95);
         else if (key == "analog_second_len") c.analog_style.second_len_pct = clamp_int(val, 70, 98);
@@ -168,6 +185,13 @@ inline bool config_read(Config& c, std::istream& f) {
         else if (key == "analog_second_thick") c.analog_style.second_thickness = clamp_int(val, 1, 3);
         else if (key == "analog_hour_tick") c.analog_style.hour_tick_pct = clamp_int(val, 5, 20);
         else if (key == "analog_minute_tick") c.analog_style.minute_tick_pct = clamp_int(val, 2, 10);
+        else if (key == "analog_center_dot_size") c.analog_style.center_dot_size = clamp_int(val, 0, 10);
+        else if (key == "analog_hour_opacity") c.analog_style.hour_opacity_pct = clamp_int(val, 10, 100);
+        else if (key == "analog_minute_opacity") c.analog_style.minute_opacity_pct = clamp_int(val, 10, 100);
+        else if (key == "analog_second_opacity") c.analog_style.second_opacity_pct = clamp_int(val, 10, 100);
+        else if (key == "analog_tick_opacity") c.analog_style.tick_opacity_pct = clamp_int(val, 10, 100);
+        else if (key == "analog_face_opacity") c.analog_style.face_opacity_pct = clamp_int(val, 0, 100);
+        else if (key == "analog_radius") c.analog_style.radius_pct = clamp_int(val, 50, 100);
         else if (key == "analog_show_min_ticks") c.analog_style.show_minute_ticks = val != 0;
         else if (key == "analog_hour_labels") c.analog_style.hour_labels = (HourLabels)clamp_int(val, 0, 2);
         else if (key == "sw_running")

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -186,9 +186,23 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
     AnalogClockStyle hi_style = style;
     draw_analog_clock_native(mem_dc.h, hi, hi_style, theme, dpi * AA_SCALE, hour, minute, second);
 
-    int old_mode = SetStretchBltMode(hdc, HALFTONE);
-    SetBrushOrgEx(hdc, 0, 0, nullptr);
-    StretchBlt(hdc, area.left, area.top, w, h, mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
-    SetStretchBltMode(hdc, old_mode);
+    BOOL blit_ok = FALSE;
+    int saved_dc = SaveDC(hdc);
+    if (saved_dc != 0) {
+        SetStretchBltMode(hdc, HALFTONE);
+        SetBrushOrgEx(hdc, 0, 0, nullptr);
+        blit_ok = StretchBlt(hdc, area.left, area.top, w, h,
+                             mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
+        RestoreDC(hdc, saved_dc);
+    } else {
+        int old_mode = SetStretchBltMode(hdc, HALFTONE);
+        SetBrushOrgEx(hdc, 0, 0, nullptr);
+        blit_ok = StretchBlt(hdc, area.left, area.top, w, h,
+                             mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
+        SetStretchBltMode(hdc, old_mode);
+    }
+
     SelectObject(mem_dc.h, old_bmp);
+    if (!blit_ok)
+        draw_analog_clock_native(hdc, area, style, theme, dpi, hour, minute, second);
 }

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <windows.h>
+#include <algorithm>
 #include <cmath>
 #include "config.hpp"
 #include "gdi.hpp"
@@ -14,24 +15,49 @@ struct AnalogResolvedColors {
     COLORREF hour;
     COLORREF minute;
     COLORREF second;
-    COLORREF face;
+    COLORREF background;
+    COLORREF face_fill;
+    COLORREF face_outline;
     COLORREF tick;
+    COLORREF hour_label;
+    COLORREF center_dot;
 };
+
+inline COLORREF analog_pick_color(int configured, COLORREF fallback) {
+    return configured >= 0 ? (COLORREF)configured : fallback;
+}
+
+inline COLORREF analog_blend(COLORREF fg, COLORREF bg, int opacity_pct) {
+    opacity_pct = std::clamp(opacity_pct, 0, 100);
+    auto mix = [&](int f, int b) { return (f * opacity_pct + b * (100 - opacity_pct)) / 100; };
+    return RGB(mix(GetRValue(fg), GetRValue(bg)),
+               mix(GetGValue(fg), GetGValue(bg)),
+               mix(GetBValue(fg), GetBValue(bg)));
+}
 
 inline AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style,
                                                    const Theme& theme) {
+    COLORREF background = analog_pick_color(style.background_color, theme.bg);
+    COLORREF outline = analog_pick_color(style.face_outline_color,
+                         analog_pick_color(style.face_color, theme.divider));
     return {
-        .hour   = style.hour_color >= 0 ? (COLORREF)style.hour_color : theme.text,
-        .minute = style.minute_color >= 0 ? (COLORREF)style.minute_color : theme.text,
-        .second = style.second_color >= 0 ? (COLORREF)style.second_color : theme.dim,
-        .face   = style.face_color >= 0 ? (COLORREF)style.face_color : theme.divider,
-        .tick   = style.tick_color >= 0 ? (COLORREF)style.tick_color : theme.dim,
+        .hour        = analog_blend(analog_pick_color(style.hour_color, theme.text), background, style.hour_opacity_pct),
+        .minute      = analog_blend(analog_pick_color(style.minute_color, theme.text), background, style.minute_opacity_pct),
+        .second      = analog_blend(analog_pick_color(style.second_color, theme.dim), background, style.second_opacity_pct),
+        .background  = background,
+        .face_fill   = analog_blend(analog_pick_color(style.face_fill_color, background), background, style.face_opacity_pct),
+        .face_outline= analog_blend(outline, background, style.face_opacity_pct),
+        .tick        = analog_blend(analog_pick_color(style.tick_color, theme.dim), background, style.tick_opacity_pct),
+        .hour_label  = analog_blend(analog_pick_color(style.hour_label_color,
+                                          analog_pick_color(style.tick_color, theme.dim)), background, style.tick_opacity_pct),
+        .center_dot  = analog_blend(analog_pick_color(style.center_dot_color,
+                                          analog_pick_color(style.hour_color, theme.text)), background, style.hour_opacity_pct),
     };
 }
 
-inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
-                               const Theme& theme, int dpi,
-                               int hour, int minute, int second) {
+inline void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
+                                      const Theme& theme, int dpi,
+                                      int hour, int minute, int second) {
     auto colors = resolve_analog_colors(style, theme);
 
     int cx = (area.left + area.right) / 2;
@@ -39,9 +65,10 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
     int w = area.right - area.left;
     int h = area.bottom - area.top;
     int radius = (w < h ? w : h) / 2 - dpi * 6 / STANDARD_DPI;
+    radius = radius * std::clamp(style.radius_pct, 50, 100) / 100;
     if (radius < 10) return;
 
-    auto dpi_px = [&](int base) { return base * dpi / STANDARD_DPI; };
+    auto dpi_px = [&](int base) { return std::max(1, base * dpi / STANDARD_DPI); };
 
     auto angle_rad = [](double units, double total) {
         return (units / total) * 2.0 * M_PI - M_PI / 2.0;
@@ -50,18 +77,23 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
     auto line_from_center = [&](double angle, int len, COLORREF color, int thickness) {
         GdiObj pen{CreatePen(PS_SOLID, dpi_px(thickness), color)};
         auto* old_pen = (HPEN)SelectObject(hdc, pen.h);
-        int ex = cx + (int)(std::cos(angle) * len);
-        int ey = cy + (int)(std::sin(angle) * len);
+        int ex = cx + (int)std::lround(std::cos(angle) * len);
+        int ey = cy + (int)std::lround(std::sin(angle) * len);
         MoveToEx(hdc, cx, cy, nullptr);
         LineTo(hdc, ex, ey);
         SelectObject(hdc, old_pen);
     };
 
     {
-        GdiObj face_pen{CreatePen(PS_SOLID, dpi_px(1), colors.face)};
-        HBRUSH null_brush = (HBRUSH)GetStockObject(NULL_BRUSH);
+        GdiObj bg_brush{CreateSolidBrush(colors.background)};
+        FillRect(hdc, &area, (HBRUSH)bg_brush.h);
+    }
+
+    {
+        GdiObj face_pen{CreatePen(PS_SOLID, dpi_px(1), colors.face_outline)};
+        GdiObj face_brush{CreateSolidBrush(colors.face_fill)};
         auto* old_pen = (HPEN)SelectObject(hdc, face_pen.h);
-        auto* old_brush = (HBRUSH)SelectObject(hdc, null_brush);
+        auto* old_brush = (HBRUSH)SelectObject(hdc, face_brush.h);
         Ellipse(hdc, cx - radius, cy - radius, cx + radius, cy + radius);
         SelectObject(hdc, old_pen);
         SelectObject(hdc, old_brush);
@@ -77,10 +109,10 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
         int thickness = is_hour_mark ? dpi_px(2) : dpi_px(1);
         GdiObj tick_pen{CreatePen(PS_SOLID, thickness, colors.tick)};
         auto* old_pen = (HPEN)SelectObject(hdc, tick_pen.h);
-        int ox = cx + (int)(std::cos(a) * outer);
-        int oy = cy + (int)(std::sin(a) * outer);
-        int ix = cx + (int)(std::cos(a) * inner);
-        int iy = cy + (int)(std::sin(a) * inner);
+        int ox = cx + (int)std::lround(std::cos(a) * outer);
+        int oy = cy + (int)std::lround(std::sin(a) * outer);
+        int ix = cx + (int)std::lround(std::cos(a) * inner);
+        int iy = cy + (int)std::lround(std::sin(a) * inner);
         MoveToEx(hdc, ox, oy, nullptr);
         LineTo(hdc, ix, iy);
         SelectObject(hdc, old_pen);
@@ -88,7 +120,7 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
 
     if (style.hour_labels != HourLabels::None) {
         SetBkMode(hdc, TRANSPARENT);
-        SetTextColor(hdc, colors.tick);
+        SetTextColor(hdc, colors.hour_label);
         int label_font_h = -MulDiv(7, dpi, 72);
         GdiObj label_font{CreateFontW(label_font_h, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
                                        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
@@ -99,8 +131,8 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
             if (style.hour_labels == HourLabels::Sparse && i != 12 && i != 3 && i != 6 && i != 9)
                 continue;
             double a = angle_rad(i, 12.0);
-            int lx = cx + (int)(std::cos(a) * label_r);
-            int ly = cy + (int)(std::sin(a) * label_r);
+            int lx = cx + (int)std::lround(std::cos(a) * label_r);
+            int ly = cy + (int)std::lround(std::sin(a) * label_r);
             wchar_t buf[4];
             wsprintfW(buf, L"%d", i);
             RECT lr = {lx - dpi_px(8), ly - dpi_px(6), lx + dpi_px(8), ly + dpi_px(6)};
@@ -110,20 +142,17 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
     }
 
     double hour_angle = angle_rad(hour % 12 + minute / 60.0 + second / 3600.0, 12.0);
-    int hour_len = radius * style.hour_len_pct / 100;
-    line_from_center(hour_angle, hour_len, colors.hour, style.hour_thickness);
+    line_from_center(hour_angle, radius * style.hour_len_pct / 100, colors.hour, style.hour_thickness);
 
     double min_angle = angle_rad(minute + second / 60.0, 60.0);
-    int min_len = radius * style.minute_len_pct / 100;
-    line_from_center(min_angle, min_len, colors.minute, style.minute_thickness);
+    line_from_center(min_angle, radius * style.minute_len_pct / 100, colors.minute, style.minute_thickness);
 
     double sec_angle = angle_rad(second, 60.0);
-    int sec_len = radius * style.second_len_pct / 100;
-    line_from_center(sec_angle, sec_len, colors.second, style.second_thickness);
+    line_from_center(sec_angle, radius * style.second_len_pct / 100, colors.second, style.second_thickness);
 
-    {
-        int dot_r = dpi_px(3);
-        GdiObj dot_brush{CreateSolidBrush(colors.hour)};
+    if (style.center_dot_size > 0) {
+        int dot_r = dpi_px(style.center_dot_size);
+        GdiObj dot_brush{CreateSolidBrush(colors.center_dot)};
         GdiObj dot_pen{CreatePen(PS_NULL, 0, 0)};
         auto* old_brush = (HBRUSH)SelectObject(hdc, dot_brush.h);
         auto* old_pen = (HPEN)SelectObject(hdc, dot_pen.h);
@@ -131,4 +160,35 @@ inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
         SelectObject(hdc, old_brush);
         SelectObject(hdc, old_pen);
     }
+}
+
+inline void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
+                               const Theme& theme, int dpi,
+                               int hour, int minute, int second) {
+    int w = area.right - area.left;
+    int h = area.bottom - area.top;
+    if (w <= 0 || h <= 0) return;
+
+    constexpr int AA_SCALE = 3;
+    DcObj mem_dc{CreateCompatibleDC(hdc)};
+    if (!mem_dc.h) {
+        draw_analog_clock_native(hdc, area, style, theme, dpi, hour, minute, second);
+        return;
+    }
+    GdiObj bmp{CreateCompatibleBitmap(hdc, w * AA_SCALE, h * AA_SCALE)};
+    if (!bmp.h) {
+        draw_analog_clock_native(hdc, area, style, theme, dpi, hour, minute, second);
+        return;
+    }
+
+    auto* old_bmp = (HBITMAP)SelectObject(mem_dc.h, bmp.h);
+    RECT hi = {0, 0, w * AA_SCALE, h * AA_SCALE};
+    AnalogClockStyle hi_style = style;
+    draw_analog_clock_native(mem_dc.h, hi, hi_style, theme, dpi * AA_SCALE, hour, minute, second);
+
+    int old_mode = SetStretchBltMode(hdc, HALFTONE);
+    SetBrushOrgEx(hdc, 0, 0, nullptr);
+    StretchBlt(hdc, area.left, area.top, w, h, mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
+    SetStretchBltMode(hdc, old_mode);
+    SelectObject(mem_dc.h, old_bmp);
 }

--- a/src/ui_windows.hpp
+++ b/src/ui_windows.hpp
@@ -13,6 +13,7 @@
 
 #include "app.hpp"
 #include "dialog_style.hpp"
+#include "painting_analog.hpp"
 
 namespace ui {
 using WindowHandle = HWND;

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -80,6 +80,93 @@ static void set_child_fonts(HWND dlg, Params& p) {
     }, (LPARAM)&p);
 }
 
+
+static int* analog_color_field(AnalogClockStyle& a, int i) {
+    switch (i) {
+    case 0: return &a.hour_color;
+    case 1: return &a.minute_color;
+    case 2: return &a.second_color;
+    case 3: return &a.background_color;
+    case 4: return &a.face_fill_color;
+    case 5: return &a.face_outline_color;
+    case 6: return &a.tick_color;
+    case 7: return &a.hour_label_color;
+    case 8: return &a.center_dot_color;
+    default: return nullptr;
+    }
+}
+
+static int* analog_value_field(AnalogClockStyle& a, int i) {
+    switch (i) {
+    case 0: return &a.hour_len_pct;
+    case 1: return &a.minute_len_pct;
+    case 2: return &a.second_len_pct;
+    case 3: return &a.hour_thickness;
+    case 4: return &a.minute_thickness;
+    case 5: return &a.second_thickness;
+    case 6: return &a.hour_tick_pct;
+    case 7: return &a.minute_tick_pct;
+    case 8: return &a.center_dot_size;
+    case 9: return &a.hour_opacity_pct;
+    case 10: return &a.minute_opacity_pct;
+    case 11: return &a.second_opacity_pct;
+    case 12: return &a.tick_opacity_pct;
+    case 13: return &a.face_opacity_pct;
+    case 14: return &a.radius_pct;
+    default: return nullptr;
+    }
+}
+
+static void analog_value_range(int i, int& min_v, int& max_v, int& step) {
+    struct Range { int min_v, max_v, step; };
+    static constexpr Range ranges[ANALOG_VALUE_COUNT] = {
+        {40, 80, 5}, {60, 95, 5}, {70, 98, 4},
+        {1, 6, 1}, {1, 4, 1}, {1, 3, 1},
+        {5, 20, 1}, {2, 10, 1}, {0, 10, 1},
+        {10, 100, 10}, {10, 100, 10}, {10, 100, 10},
+        {10, 100, 10}, {0, 100, 10}, {50, 100, 5},
+    };
+    min_v = ranges[i].min_v;
+    max_v = ranges[i].max_v;
+    step = ranges[i].step;
+}
+
+static const wchar_t* analog_color_label(int i) {
+    static constexpr const wchar_t* labels[ANALOG_COLOR_COUNT] = {
+        L"Hour", L"Minute", L"Second", L"Background", L"Face fill",
+        L"Outline", L"Ticks", L"Numbers", L"Center dot"
+    };
+    return labels[i];
+}
+
+static const wchar_t* analog_value_label(int i) {
+    static constexpr const wchar_t* labels[ANALOG_VALUE_COUNT] = {
+        L"Hour length", L"Minute length", L"Second length",
+        L"Hour thickness", L"Minute thickness", L"Second thickness",
+        L"Hour tick", L"Minute tick", L"Center dot",
+        L"Hour opacity", L"Minute opacity", L"Second opacity",
+        L"Tick opacity", L"Face opacity", L"Clock radius"
+    };
+    return labels[i];
+}
+
+static COLORREF analog_palette_color(int palette_i) {
+    static constexpr COLORREF custom[] = {
+        RGB(220, 70, 70), RGB(236, 145, 42), RGB(240, 200, 60),
+        RGB(86, 180, 100), RGB(65, 160, 220), RGB(160, 110, 230),
+        RGB(235, 235, 235), RGB(35, 35, 35)
+    };
+    if (palette_i == 0) return (COLORREF)-1;
+    return custom[(palette_i - 1) % (int)(sizeof(custom) / sizeof(custom[0]))];
+}
+
+static int analog_palette_index(int color) {
+    if (color < 0) return 0;
+    for (int i = 1; i <= 8; ++i)
+        if ((COLORREF)color == analog_palette_color(i)) return i;
+    return 0;
+}
+
 static INT_PTR on_init(HWND dlg, LPARAM lp) {
     auto* p = reinterpret_cast<Params*>(lp);
     SetWindowLongPtrW(dlg, DWLP_USER, (LONG_PTR)p);
@@ -185,9 +272,13 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
         s.draw_label(hdc, lbl, L"Format");
 
         if (p->clock_view == ClockView::Analog) {
-            RECT aslbl = map_dlu(dlg, 70, 58, 90, 10);
+            RECT aslbl = map_dlu(dlg, 70, 58, 70, 10);
             aslbl.top += sdy; aslbl.bottom += sdy;
-            s.draw_label(hdc, aslbl, L"Analog options");
+            s.draw_label(hdc, aslbl, L"Live preview");
+
+            RECT preview = p->rects.analog_preview;
+            preview.top += sdy; preview.bottom += sdy;
+            draw_analog_clock(hdc, preview, p->analog_style, *s.theme, s.dpi, 10, 10, 30);
 
             RECT min_r = p->rects.analog_min_ticks;
             min_r.top += sdy; min_r.bottom += sdy;
@@ -195,7 +286,7 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
                              p->analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
                              p->analog_style.show_minute_ticks, s);
 
-            RECT hrlbl = map_dlu(dlg, 70, 86, 90, 8);
+            RECT hrlbl = map_dlu(dlg, 154, 84, 70, 8);
             hrlbl.top += sdy; hrlbl.bottom += sdy;
             s.draw_label(hdc, hrlbl, L"Hour labels");
 
@@ -205,6 +296,33 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
                 ar.top += sdy; ar.bottom += sdy;
                 paint_option_btn(hdc, ar, lbl_names[i],
                                  (int)p->analog_style.hour_labels == i, s);
+            }
+
+            RECT color_lbl = map_dlu(dlg, 154, 114, 70, 8);
+            color_lbl.top += sdy; color_lbl.bottom += sdy;
+            s.draw_label(hdc, color_lbl, L"Colors");
+            for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
+                RECT r = p->rects.analog_colors[i];
+                r.top += sdy; r.bottom += sdy;
+                int* field = analog_color_field(p->analog_style, i);
+                bool custom = field && *field >= 0;
+                paint_option_btn(hdc, r, analog_color_label(i), custom, s);
+                RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
+                COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
+                GdiObj br{CreateSolidBrush(sw_color)};
+                FillRect(hdc, &sw, (HBRUSH)br.h);
+            }
+
+            RECT value_lbl = map_dlu(dlg, 72, 246, 90, 8);
+            value_lbl.top += sdy; value_lbl.bottom += sdy;
+            s.draw_label(hdc, value_lbl, L"Size and opacity");
+            for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
+                RECT r = p->rects.analog_values[i];
+                r.top += sdy; r.bottom += sdy;
+                int* field = analog_value_field(p->analog_style, i);
+                wchar_t buf[96];
+                wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
+                paint_option_btn(hdc, r, buf, false, s);
             }
         }
 
@@ -280,7 +398,7 @@ static INT_PTR on_draw_item(HWND dlg, LPARAM lp) {
     auto* di = reinterpret_cast<DRAWITEMSTRUCT*>(lp);
     if (di->CtlType != ODT_BUTTON) return FALSE;
 
-    const wchar_t* label = (di->CtlID == IDC_SET_OK) ? L"OK" : L"Cancel";
+    const wchar_t* label = (di->CtlID == IDC_SET_OK) ? L"Apply" : L"Cancel";
     bool focused = (di->itemState & ODS_FOCUS) != 0;
     p->style.draw_button(di->hDC, di->rcItem, label, focused);
     return TRUE;
@@ -327,6 +445,30 @@ static INT_PTR on_left_button_down(HWND dlg, LPARAM lp) {
                 p->analog_style.hour_labels = (HourLabels)i;
                 InvalidateRect(dlg, nullptr, TRUE);
                 return TRUE;
+            }
+        }
+        for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
+            if (PtInRect(&p->rects.analog_colors[i], spt)) {
+                int* field = analog_color_field(p->analog_style, i);
+                if (field) {
+                    int next = (analog_palette_index(*field) + 1) % 9;
+                    *field = (int)analog_palette_color(next);
+                    InvalidateRect(dlg, nullptr, TRUE);
+                    return TRUE;
+                }
+            }
+        }
+        for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
+            if (PtInRect(&p->rects.analog_values[i], spt)) {
+                int* field = analog_value_field(p->analog_style, i);
+                if (field) {
+                    int min_v, max_v, step;
+                    analog_value_range(i, min_v, max_v, step);
+                    *field += step;
+                    if (*field > max_v) *field = min_v;
+                    InvalidateRect(dlg, nullptr, TRUE);
+                    return TRUE;
+                }
             }
         }
     }

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -150,19 +150,23 @@ static const wchar_t* analog_value_label(int i) {
     return labels[i];
 }
 
+static constexpr COLORREF ANALOG_PALETTE_COLORS[] = {
+    RGB(220, 70, 70), RGB(236, 145, 42), RGB(240, 200, 60),
+    RGB(86, 180, 100), RGB(65, 160, 220), RGB(160, 110, 230),
+    RGB(235, 235, 235), RGB(35, 35, 35),
+};
+static constexpr int ANALOG_CUSTOM_PALETTE_COUNT =
+    (int)(sizeof(ANALOG_PALETTE_COLORS) / sizeof(ANALOG_PALETTE_COLORS[0]));
+static constexpr int ANALOG_PALETTE_COUNT = ANALOG_CUSTOM_PALETTE_COUNT + 1; // auto + custom colors
+
 static COLORREF analog_palette_color(int palette_i) {
-    static constexpr COLORREF custom[] = {
-        RGB(220, 70, 70), RGB(236, 145, 42), RGB(240, 200, 60),
-        RGB(86, 180, 100), RGB(65, 160, 220), RGB(160, 110, 230),
-        RGB(235, 235, 235), RGB(35, 35, 35)
-    };
     if (palette_i == 0) return (COLORREF)-1;
-    return custom[(palette_i - 1) % (int)(sizeof(custom) / sizeof(custom[0]))];
+    return ANALOG_PALETTE_COLORS[(palette_i - 1) % ANALOG_CUSTOM_PALETTE_COUNT];
 }
 
 static int analog_palette_index(int color) {
     if (color < 0) return 0;
-    for (int i = 1; i <= 8; ++i)
+    for (int i = 1; i < ANALOG_PALETTE_COUNT; ++i)
         if ((COLORREF)color == analog_palette_color(i)) return i;
     return 0;
 }
@@ -451,7 +455,7 @@ static INT_PTR on_left_button_down(HWND dlg, LPARAM lp) {
             if (PtInRect(&p->rects.analog_colors[i], spt)) {
                 int* field = analog_color_field(p->analog_style, i);
                 if (field) {
-                    int next = (analog_palette_index(*field) + 1) % 9;
+                    int next = (analog_palette_index(*field) + 1) % ANALOG_PALETTE_COUNT;
                     *field = (int)analog_palette_color(next);
                     InvalidateRect(dlg, nullptr, TRUE);
                     return TRUE;

--- a/src/ui_windows_settings_dialog_scroll.hpp
+++ b/src/ui_windows_settings_dialog_scroll.hpp
@@ -55,12 +55,18 @@ static int tab_painted_content_bottom(HWND dlg, const Params& p) {
         if (p.clock_view != ClockView::Analog) {
             return map_dlu(dlg, 70, 28, 80, 12).bottom;
         }
-        return std::max({
+        int bottom = std::max({
+            rect_bottom_after_scroll(p.rects.analog_preview, p),
             rect_bottom_after_scroll(p.rects.analog_min_ticks, p),
             rect_bottom_after_scroll(p.rects.analog_labels[0], p),
             rect_bottom_after_scroll(p.rects.analog_labels[1], p),
             rect_bottom_after_scroll(p.rects.analog_labels[2], p),
         });
+        for (int i = 0; i < ANALOG_COLOR_COUNT; ++i)
+            bottom = std::max(bottom, rect_bottom_after_scroll(p.rects.analog_colors[i], p));
+        for (int i = 0; i < ANALOG_VALUE_COUNT; ++i)
+            bottom = std::max(bottom, rect_bottom_after_scroll(p.rects.analog_values[i], p));
+        return bottom;
     case TAB_POMODORO:
         return rect_bottom_after_scroll(p.rects.auto_start, p);
     case TAB_TIMERS:

--- a/src/ui_windows_settings_dialog_scroll.hpp
+++ b/src/ui_windows_settings_dialog_scroll.hpp
@@ -51,7 +51,7 @@ static int tab_painted_content_bottom(HWND dlg, const Params& p) {
             rect_bottom_after_scroll(p.rects.theme[2], p),
             rect_bottom_after_scroll(p.rects.sound, p),
         });
-    case TAB_CLOCK:
+    case TAB_CLOCK: {
         if (p.clock_view != ClockView::Analog) {
             return map_dlu(dlg, 70, 28, 80, 12).bottom;
         }
@@ -67,6 +67,7 @@ static int tab_painted_content_bottom(HWND dlg, const Params& p) {
         for (int i = 0; i < ANALOG_VALUE_COUNT; ++i)
             bottom = std::max(bottom, rect_bottom_after_scroll(p.rects.analog_values[i], p));
         return bottom;
+    }
     case TAB_POMODORO:
         return rect_bottom_after_scroll(p.rects.auto_start, p);
     case TAB_TIMERS:

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -6,14 +6,20 @@ static RECT map_dlu(HWND dlg, short x, short y, short cx, short cy) {
     return r;
 }
 
+constexpr int ANALOG_COLOR_COUNT = 9;
+constexpr int ANALOG_VALUE_COUNT = 15;
+
 struct HitRects {
     RECT sidebar[TAB_COUNT];
     RECT theme[3];
     RECT sound;
     RECT auto_start;
     RECT preset_row[5];
+    RECT analog_preview;
     RECT analog_min_ticks;
     RECT analog_labels[3];
+    RECT analog_colors[ANALOG_COLOR_COUNT];
+    RECT analog_values[ANALOG_VALUE_COUNT];
 };
 
 static HitRects compute_rects(HWND dlg) {
@@ -27,11 +33,16 @@ static HitRects compute_rects(HWND dlg) {
     h.theme[1] = map_dlu(dlg, 70, 57, 54, 13);
     h.theme[2] = map_dlu(dlg, 70, 72, 54, 13);
 
-    // Analog settings sit below the format dropdown (which is at y=40, h=12)
-    h.analog_min_ticks = map_dlu(dlg, 70,  72, 80, 12);
-    h.analog_labels[0] = map_dlu(dlg, 70,  96, 34, 12);
-    h.analog_labels[1] = map_dlu(dlg, 106, 96, 34, 12);
-    h.analog_labels[2] = map_dlu(dlg, 142, 96, 34, 12);
+    // Analog settings sit below the format dropdown (which is at y=40, h=12).
+    h.analog_preview = map_dlu(dlg, 72, 58, 72, 72);
+    h.analog_min_ticks = map_dlu(dlg, 154,  64, 68, 12);
+    h.analog_labels[0] = map_dlu(dlg, 154,  94, 24, 12);
+    h.analog_labels[1] = map_dlu(dlg, 180, 94, 26, 12);
+    h.analog_labels[2] = map_dlu(dlg, 208, 94, 24, 12);
+    for (int i = 0; i < ANALOG_COLOR_COUNT; ++i)
+        h.analog_colors[i] = map_dlu(dlg, 154, (short)(124 + i * 14), 70, 12);
+    for (int i = 0; i < ANALOG_VALUE_COUNT; ++i)
+        h.analog_values[i] = map_dlu(dlg, 72, (short)(256 + i * 14), 152, 12);
 
     h.sound      = map_dlu(dlg, 70,  97, 100, 13);
     h.auto_start = map_dlu(dlg, 70, 115, 100, 13);

--- a/src/ui_windows_settings_dialog_template.hpp
+++ b/src/ui_windows_settings_dialog_template.hpp
@@ -98,7 +98,7 @@ static std::vector<WORD> build_template() {
     short btn_x0 = SIDEBAR_W + 2 + (content_cx - total_bw) / 2;
     short btn_y = 138;
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
-             btn_x0, btn_y, btn_w, btn_h, IDC_SET_OK, CLS_BUTTON, L"OK");
+             btn_x0, btn_y, btn_w, btn_h, IDC_SET_OK, CLS_BUTTON, L"Apply");
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
              btn_x0 + btn_w + btn_gap, btn_y, btn_w, btn_h, IDC_SET_CANCEL, CLS_BUTTON, L"Cancel");
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -461,12 +461,24 @@ TEST_CASE("Config analog style defaults", "[config]") {
     REQUIRE(s.second_color == -1);
     REQUIRE(s.face_color == -1);
     REQUIRE(s.tick_color == -1);
+    REQUIRE(s.background_color == -1);
+    REQUIRE(s.face_fill_color == -1);
+    REQUIRE(s.face_outline_color == -1);
+    REQUIRE(s.hour_label_color == -1);
+    REQUIRE(s.center_dot_color == -1);
     REQUIRE(s.hour_len_pct == 60);
     REQUIRE(s.minute_len_pct == 80);
     REQUIRE(s.second_len_pct == 90);
     REQUIRE(s.hour_thickness == 4);
     REQUIRE(s.minute_thickness == 2);
     REQUIRE(s.second_thickness == 1);
+    REQUIRE(s.center_dot_size == 3);
+    REQUIRE(s.hour_opacity_pct == 100);
+    REQUIRE(s.minute_opacity_pct == 100);
+    REQUIRE(s.second_opacity_pct == 100);
+    REQUIRE(s.tick_opacity_pct == 100);
+    REQUIRE(s.face_opacity_pct == 100);
+    REQUIRE(s.radius_pct == 100);
     REQUIRE(s.show_minute_ticks);
     REQUIRE(s.hour_labels == HourLabels::Sparse);
 }
@@ -478,6 +490,11 @@ TEST_CASE("Config analog style round-trip", "[config]") {
     orig.analog_style.second_color = 0x0000FF;
     orig.analog_style.face_color = 0xAAAAAA;
     orig.analog_style.tick_color = 0x555555;
+    orig.analog_style.background_color = 0x101010;
+    orig.analog_style.face_fill_color = 0x202020;
+    orig.analog_style.face_outline_color = 0x303030;
+    orig.analog_style.hour_label_color = 0x404040;
+    orig.analog_style.center_dot_color = 0x505050;
     orig.analog_style.hour_len_pct = 55;
     orig.analog_style.minute_len_pct = 85;
     orig.analog_style.second_len_pct = 95;
@@ -486,6 +503,13 @@ TEST_CASE("Config analog style round-trip", "[config]") {
     orig.analog_style.second_thickness = 2;
     orig.analog_style.hour_tick_pct = 15;
     orig.analog_style.minute_tick_pct = 7;
+    orig.analog_style.center_dot_size = 6;
+    orig.analog_style.hour_opacity_pct = 90;
+    orig.analog_style.minute_opacity_pct = 80;
+    orig.analog_style.second_opacity_pct = 70;
+    orig.analog_style.tick_opacity_pct = 60;
+    orig.analog_style.face_opacity_pct = 50;
+    orig.analog_style.radius_pct = 75;
     orig.analog_style.show_minute_ticks = false;
     orig.analog_style.hour_labels = HourLabels::Full;
 
@@ -501,6 +525,11 @@ TEST_CASE("Config analog style round-trip", "[config]") {
     REQUIRE(back.analog_style.second_color == 0x0000FF);
     REQUIRE(back.analog_style.face_color == 0xAAAAAA);
     REQUIRE(back.analog_style.tick_color == 0x555555);
+    REQUIRE(back.analog_style.background_color == 0x101010);
+    REQUIRE(back.analog_style.face_fill_color == 0x202020);
+    REQUIRE(back.analog_style.face_outline_color == 0x303030);
+    REQUIRE(back.analog_style.hour_label_color == 0x404040);
+    REQUIRE(back.analog_style.center_dot_color == 0x505050);
     REQUIRE(back.analog_style.hour_len_pct == 55);
     REQUIRE(back.analog_style.minute_len_pct == 85);
     REQUIRE(back.analog_style.second_len_pct == 95);
@@ -509,6 +538,13 @@ TEST_CASE("Config analog style round-trip", "[config]") {
     REQUIRE(back.analog_style.second_thickness == 2);
     REQUIRE(back.analog_style.hour_tick_pct == 15);
     REQUIRE(back.analog_style.minute_tick_pct == 7);
+    REQUIRE(back.analog_style.center_dot_size == 6);
+    REQUIRE(back.analog_style.hour_opacity_pct == 90);
+    REQUIRE(back.analog_style.minute_opacity_pct == 80);
+    REQUIRE(back.analog_style.second_opacity_pct == 70);
+    REQUIRE(back.analog_style.tick_opacity_pct == 60);
+    REQUIRE(back.analog_style.face_opacity_pct == 50);
+    REQUIRE(back.analog_style.radius_pct == 75);
     REQUIRE_FALSE(back.analog_style.show_minute_ticks);
     REQUIRE(back.analog_style.hour_labels == HourLabels::Full);
 }
@@ -521,10 +557,13 @@ TEST_CASE("Config analog style not written when defaults", "[config]") {
 }
 
 TEST_CASE("Config analog style values clamped", "[config]") {
-    std::istringstream is("analog_hour_len=100\nanalog_minute_thick=10\nanalog_hour_labels=5\n");
+    std::istringstream is("analog_hour_len=100\nanalog_minute_thick=10\nanalog_hour_labels=5\nanalog_radius=20\nanalog_face_opacity=-5\nanalog_center_dot_size=99\n");
     Config c;
     config_read(c, is);
     REQUIRE(c.analog_style.hour_len_pct == 80);
     REQUIRE(c.analog_style.minute_thickness == 4);
     REQUIRE(c.analog_style.hour_labels == HourLabels::Full);
+    REQUIRE(c.analog_style.radius_pct == 50);
+    REQUIRE(c.analog_style.face_opacity_pct == 0);
+    REQUIRE(c.analog_style.center_dot_size == 10);
 }


### PR DESCRIPTION
### Motivation
- Provide richer analog clock customization (separate face fill/outline, background, label and center-dot colors, per-hand opacities, radius and center-dot size) and a live preview in the settings dialog.
- Preserve `face_color` as a legacy outline color for backward compatibility while introducing new fields.

### Description
- Extended `AnalogClockStyle` with new fields: `background_color`, `face_fill_color`, `face_outline_color`, `hour_label_color`, `center_dot_color`, `center_dot_size`, `hour_opacity_pct`, `minute_opacity_pct`, `second_opacity_pct`, `tick_opacity_pct`, `face_opacity_pct`, and `radius_pct`, and annotated `face_color` as legacy.
- Added serialization support in `config_read`/`config_write` for the new `analog_...` keys and clamped their input ranges where appropriate.
- Implemented color resolution and blending via `analog_pick_color`, `analog_blend` and `resolve_analog_colors` so configured colors blend with the background according to opacity settings.
- Reworked analog rendering by splitting drawing into `draw_analog_clock_native` (core drawing, DPI fixes and safer rounding) and a new high-quality `draw_analog_clock` that renders to a higher-resolution bitmap and downscales for simple anti-aliasing (fallbacks to native path on failure).
- Added UI plumbing: preview drawing in the clock settings tab, interactive color/value controls and helpers (`analog_color_field`, `analog_value_field`, labels, palette helpers), hit-rects and layout updates, and changed the settings button label to `Apply`.

### Testing
- Updated and executed unit tests in `tests/test_config.cpp`: `Config analog style defaults`, `Config analog style round-trip`, `Config analog style not written when defaults`, and `Config analog style values clamped`, and they all passed.
- Existing config serialization tests (related to presets and other fields) were run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bb155f08832c8b0c47e242ae8ea8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded analog clock customization: per-element colors (background, face fill/outline, hour labels, center dot), per-element opacity percentages, center-dot size and radius controls.
  * Live preview in Settings with interactive color and value controls.

* **Improvements**
  * Higher-quality analog rendering with anti-aliased, supersampled drawing and improved label coloring.
  * Settings dialog primary button label changed to “Apply”.

* **Tests**
  * Extended tests for analog style defaults, serialization round-trip, and clamping of new fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/314)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->