### PR TITLE
fix: eliminate extra space at bottom of lowest widget on non-round DPI

### DIFF
--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -113,7 +113,8 @@ inline int paint_stopwatch(HDC hdc, int cw, int y, PaintCtx& ctx, std::chrono::s
     int gbw = layout.dpi_scale(100), gbh = layout.dpi_scale(18);
     auto lap_label = ctx.app.lap_write_failed ? L"Get Laps (!)" : L"Get Laps";
     auto lap_col = ctx.app.lap_write_failed ? th.expire : has_file ? th.btn : th.dim;
-    btn(hdc, {(cw - gbw) / 2, by0 + bh + layout.dpi_scale(24), (cw + gbw) / 2, by0 + bh + layout.dpi_scale(24) + gbh},
+    int laps_top = y + layout.sw_h - gbh;
+    btn(hdc, {(cw - gbw) / 2, laps_top, (cw + gbw) / 2, y + layout.sw_h},
         false, lap_label, has_file ? A_SW_GET : 0, ctx, lap_col);
     return y + layout.sw_h;
 }

--- a/src/painting_timer.hpp
+++ b/src/painting_timer.hpp
@@ -140,7 +140,6 @@ inline void paint_timer_controls(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     CHRONOS_ASSERT(i >= 0 && i < (int)ctx.app.timers.size());
     auto& layout = ctx.layout;
     auto& ts = ctx.app.timers[i];
-    auto m = TimerMetrics::from(layout);
     int gap = layout.dpi_scale(6), bh = layout.dpi_scale(28);
     int by_off = layout.tmr_h - bh;
     bool running = ts.t.is_running();

--- a/src/painting_timer.hpp
+++ b/src/painting_timer.hpp
@@ -142,7 +142,7 @@ inline void paint_timer_controls(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     auto& ts = ctx.app.timers[i];
     auto m = TimerMetrics::from(layout);
     int gap = layout.dpi_scale(6), bh = layout.dpi_scale(28);
-    int by_off = m.dn_off + m.abh + gap;
+    int by_off = layout.tmr_h - bh;
     bool running = ts.t.is_running();
 
     SelectObject(hdc, ctx.res.fontSm);

--- a/src/ui_windows_settings_dialog_template.hpp
+++ b/src/ui_windows_settings_dialog_template.hpp
@@ -39,7 +39,7 @@ static std::vector<WORD> build_template() {
     short lbl_x = 72, lbl_w = 50;
     short ed_x = 126, ed_w = 28;
     short min_x = 158, min_w = 18;
-    short row_h = 12;
+    short row_h = 10;
     short y0 = 40, sp = 18;
 
     add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -70,7 +70,7 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         {
             RECT cr;
             GetClientRect(hwnd, &cr);
-            if (cr.bottom > client_height(*s))
+            if (cr.bottom != client_height(*s))
                 resize_window(hwnd, *s);
         }
         break;


### PR DESCRIPTION
## Summary

Fixes #293 — extra blank space visible at the bottom of the lowest widget on portrait/vertical screens, plus extra whitespace inside settings input boxes.

**Root cause — main window:** At non-round DPI values (125%, 133%, 167%, …) `dpi_scale()` integer truncation means individual offset additions within a widget don't sum to exactly `sw_h`/`tmr_h`. Because `paint_all` fills the full client background first, the 1–4 px gap at the bottom of the last painted element shows as background-coloured empty space — but only on the *lowest* visible widget (adjacent widgets paint over each other's gap).

**Root cause — settings input boxes:** `row_h = 12` DLU is sized against the system dialog font (Segoe UI 9 pt), which maps to ~22 px. The custom 11 pt font we apply via `WM_SETFONT` renders glyphs ~14 px tall, leaving ~8 px of blank space below the text cursor.

**Changes:**
- `painting.hpp`: snap Get Laps button bottom to `y + sw_h` (anchored to widget edge instead of accumulated offsets)
- `painting_timer.hpp`: derive `by_off` from `tmr_h - bh` so the Start/Stop/Reset row is also anchored to the widget bottom
- `ui_windows_settings_dialog_template.hpp`: reduce `row_h` 12 → 10 DLU so edit controls fit the 11 pt custom font with reasonable padding
- `window.hpp` `WM_SIZE`: widen guard from `>` to `!=` — corrects both too-tall and too-short mismatches

## Test plan
- [ ] Run at 100% DPI: layout unchanged (arithmetic is identical at 96 DPI)
- [ ] Run at 125% DPI: no background strip visible below lowest widget
- [ ] Run at 133% DPI: same
- [ ] Open Settings → Pomodoro and Timers tabs: input boxes have tight, symmetrical padding with no blank strip below typed text
- [ ] Toggle widgets (Clock/Stopwatch/Timers) — window resizes cleanly with no extra space

https://claude.ai/code/session_01TaejfQhk9uTGNzBVTtQZWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaejfQhk9uTGNzBVTtQZWW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined button and control positioning in the stopwatch interface for improved layout accuracy.
  * Optimized vertical spacing of timer control buttons to enhance visual consistency.
  * Reduced row spacing in settings dialog templates for more efficient screen use.
  * Improved window resize detection so the app responds correctly to all dimension changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/321)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->