### PR TITLE
fix: update analog arm-length clamp test for 0-100 range

### DIFF
--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -177,9 +177,9 @@ inline bool config_read(Config& c, std::istream& f) {
         else if (key == "analog_face_outline_color") c.analog_style.face_outline_color = (int)val;
         else if (key == "analog_hour_label_color") c.analog_style.hour_label_color = (int)val;
         else if (key == "analog_center_dot_color") c.analog_style.center_dot_color = (int)val;
-        else if (key == "analog_hour_len") c.analog_style.hour_len_pct = clamp_int(val, 40, 80);
-        else if (key == "analog_minute_len") c.analog_style.minute_len_pct = clamp_int(val, 60, 95);
-        else if (key == "analog_second_len") c.analog_style.second_len_pct = clamp_int(val, 70, 98);
+        else if (key == "analog_hour_len") c.analog_style.hour_len_pct = clamp_int(val, 0, 100);
+        else if (key == "analog_minute_len") c.analog_style.minute_len_pct = clamp_int(val, 0, 100);
+        else if (key == "analog_second_len") c.analog_style.second_len_pct = clamp_int(val, 0, 100);
         else if (key == "analog_hour_thick") c.analog_style.hour_thickness = clamp_int(val, 1, 6);
         else if (key == "analog_minute_thick") c.analog_style.minute_thickness = clamp_int(val, 1, 4);
         else if (key == "analog_second_thick") c.analog_style.second_thickness = clamp_int(val, 1, 3);

--- a/src/painting_analog.hpp
+++ b/src/painting_analog.hpp
@@ -142,13 +142,16 @@ inline void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle&
     }
 
     double hour_angle = angle_rad(hour % 12 + minute / 60.0 + second / 3600.0, 12.0);
-    line_from_center(hour_angle, radius * style.hour_len_pct / 100, colors.hour, style.hour_thickness);
+    if (style.hour_len_pct > 0)
+        line_from_center(hour_angle, radius * style.hour_len_pct / 100, colors.hour, style.hour_thickness);
 
     double min_angle = angle_rad(minute + second / 60.0, 60.0);
-    line_from_center(min_angle, radius * style.minute_len_pct / 100, colors.minute, style.minute_thickness);
+    if (style.minute_len_pct > 0)
+        line_from_center(min_angle, radius * style.minute_len_pct / 100, colors.minute, style.minute_thickness);
 
     double sec_angle = angle_rad(second, 60.0);
-    line_from_center(sec_angle, radius * style.second_len_pct / 100, colors.second, style.second_thickness);
+    if (style.second_len_pct > 0)
+        line_from_center(sec_angle, radius * style.second_len_pct / 100, colors.second, style.second_thickness);
 
     if (style.center_dot_size > 0) {
         int dot_r = dpi_px(style.center_dot_size);

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -120,7 +120,7 @@ static int* analog_value_field(AnalogClockStyle& a, int i) {
 static void analog_value_range(int i, int& min_v, int& max_v, int& step) {
     struct Range { int min_v, max_v, step; };
     static constexpr Range ranges[ANALOG_VALUE_COUNT] = {
-        {40, 80, 5}, {60, 95, 5}, {70, 98, 4},
+        {0, 100, 5}, {0, 100, 5}, {0, 100, 5},
         {1, 6, 1}, {1, 4, 1}, {1, 3, 1},
         {5, 20, 1}, {2, 10, 1}, {0, 10, 1},
         {10, 100, 10}, {10, 100, 10}, {10, 100, 10},

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -557,10 +557,10 @@ TEST_CASE("Config analog style not written when defaults", "[config]") {
 }
 
 TEST_CASE("Config analog style values clamped", "[config]") {
-    std::istringstream is("analog_hour_len=100\nanalog_minute_thick=10\nanalog_hour_labels=5\nanalog_radius=20\nanalog_face_opacity=-5\nanalog_center_dot_size=99\n");
+    std::istringstream is("analog_hour_len=150\nanalog_minute_thick=10\nanalog_hour_labels=5\nanalog_radius=20\nanalog_face_opacity=-5\nanalog_center_dot_size=99\n");
     Config c;
     config_read(c, is);
-    REQUIRE(c.analog_style.hour_len_pct == 80);
+    REQUIRE(c.analog_style.hour_len_pct == 100);
     REQUIRE(c.analog_style.minute_thickness == 4);
     REQUIRE(c.analog_style.hour_labels == HourLabels::Full);
     REQUIRE(c.analog_style.radius_pct == 50);


### PR DESCRIPTION
## Summary

- Cherry-picks the `feat: clock arm lengths as 0-100% of radius, 0 hides the arm` commit from `claude/youthful-mayer-trVU4`
- Fixes the accompanying test that was not updated when the clamp ranges changed from `[40,80]`/`[60,95]`/`[70,98]` to `[0,100]`
- The test now uses `analog_hour_len=150` (clearly over the new max) and expects it clamped to `100`, which correctly validates the new behavior

## Test plan

- [ ] `Config analog style values clamped` passes on Linux Release, Linux Debug, sanitizer, and Windows
- [ ] All other 244 tests continue to pass

Fixes #324 #325 #326 #327

https://claude.ai/code/session_01W9KNFNUy4AiLdiTmCbK56Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9KNFNUy4AiLdiTmCbK56Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analog clock hand lengths now configurable across the full 0-100% range.

* **Improvements**
  * Optimized rendering by not drawing analog clock hands with zero length.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/328)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->