### PR TITLE
fix: clock config dialog — wider layout, sticky preview, resizable/movable

### DIFF
--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -215,7 +215,7 @@ static INT_PTR on_resize(HWND dlg, WPARAM wp) {
 
 static INT_PTR on_get_min_max_info(HWND dlg, LPARAM lp) {
     auto* mm = reinterpret_cast<MINMAXINFO*>(lp);
-    RECT r{0, 0, 200, 140};
+    RECT r{0, 0, DLG_W, DLG_H};
     MapDialogRect(dlg, &r);
     int frame_x = GetSystemMetrics(SM_CXSIZEFRAME);
     int frame_y = GetSystemMetrics(SM_CYSIZEFRAME);

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -171,6 +171,58 @@ static int analog_palette_index(int color) {
     return 0;
 }
 
+static void reposition_buttons(HWND dlg) {
+    HWND ok_btn = GetDlgItem(dlg, IDC_SET_OK);
+    HWND cancel_btn = GetDlgItem(dlg, IDC_SET_CANCEL);
+    if (!ok_btn || !cancel_btn) return;
+
+    RECT rc{};
+    GetClientRect(dlg, &rc);
+
+    RECT ok_wr{}, cancel_wr{};
+    GetWindowRect(ok_btn, &ok_wr);
+    GetWindowRect(cancel_btn, &cancel_wr);
+    int bw = ok_wr.right - ok_wr.left;
+    int bh = ok_wr.bottom - ok_wr.top;
+    int cw = cancel_wr.right - cancel_wr.left;
+
+    RECT gaps{0, 0, 8, 4};
+    MapDialogRect(dlg, &gaps);
+    int gap = gaps.right;
+    int bot_margin = gaps.bottom;
+
+    RECT sb{0, 0, SIDEBAR_W, 0};
+    MapDialogRect(dlg, &sb);
+    int content_left = sb.right;
+    int content_w = rc.right - content_left;
+    int total_bw = bw + gap + cw;
+    int btn_x0 = content_left + (content_w - total_bw) / 2;
+    int btn_y = rc.bottom - bh - bot_margin;
+
+    SetWindowPos(ok_btn,     nullptr, btn_x0,            btn_y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+    SetWindowPos(cancel_btn, nullptr, btn_x0 + bw + gap, btn_y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+}
+
+static INT_PTR on_resize(HWND dlg, WPARAM wp) {
+    if (wp == SIZE_MINIMIZED) return FALSE;
+    auto* p = dialog_params(dlg);
+    if (!p) return FALSE;
+    reposition_buttons(dlg);
+    update_content_scroll(dlg, p);
+    InvalidateRect(dlg, nullptr, TRUE);
+    return TRUE;
+}
+
+static INT_PTR on_get_min_max_info(HWND dlg, LPARAM lp) {
+    auto* mm = reinterpret_cast<MINMAXINFO*>(lp);
+    RECT r{0, 0, 200, 140};
+    MapDialogRect(dlg, &r);
+    int frame_x = GetSystemMetrics(SM_CXSIZEFRAME);
+    int frame_y = GetSystemMetrics(SM_CYSIZEFRAME);
+    mm->ptMinTrackSize = {r.right + 2 * frame_x, r.bottom + 2 * frame_y};
+    return TRUE;
+}
+
 static INT_PTR on_init(HWND dlg, LPARAM lp) {
     auto* p = reinterpret_cast<Params*>(lp);
     SetWindowLongPtrW(dlg, DWLP_USER, (LONG_PTR)p);
@@ -178,13 +230,14 @@ static INT_PTR on_init(HWND dlg, LPARAM lp) {
     center_dialog_on_parent(dlg);
 
     p->rects = compute_rects(dlg);
-    p->clock_combo_rc = map_dlu(dlg, 68, 40, 162, 80);
+    p->clock_combo_rc = map_dlu(dlg, 68, 40, 212, 80);
 
     tab_pomodoro_init(dlg, *p);
     tab_timers_init(dlg, *p);
     tab_clock_init(dlg, *p);
     set_child_fonts(dlg, *p);
     set_initial_tab_visibility(dlg, *p);
+    reposition_buttons(dlg);
     return FALSE;
 }
 
@@ -220,10 +273,9 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
     MoveToEx(hdc, sb.right, div_y.bottom, nullptr);
     LineTo(hdc, sb.right, rc.bottom);
 
-    RECT btn_div = {0, 0, 0, 132};
-    MapDialogRect(dlg, &btn_div);
-    MoveToEx(hdc, sb.right, btn_div.bottom, nullptr);
-    LineTo(hdc, rc.right, btn_div.bottom);
+    int btn_area_top = content_area_bottom(dlg);
+    MoveToEx(hdc, sb.right, btn_area_top, nullptr);
+    LineTo(hdc, rc.right, btn_area_top);
 
     SelectObject(hdc, old_pen);
     DeleteObject(div_pen);
@@ -233,7 +285,7 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
         paint_option_btn(hdc, p->rects.sidebar[i], tab_names[i], i == p->active_tab, s);
 
     int save_dc = SaveDC(hdc);
-    IntersectClipRect(hdc, sb.right + 1, div_y.bottom + 1, rc.right, btn_div.bottom);
+    IntersectClipRect(hdc, sb.right + 1, div_y.bottom + 1, rc.right, btn_area_top);
 
     int sdy = -p->scroll_y;
 
@@ -276,58 +328,65 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
         s.draw_label(hdc, lbl, L"Format");
 
         if (p->clock_view == ClockView::Analog) {
-            RECT aslbl = map_dlu(dlg, 70, 58, 70, 10);
-            aslbl.top += sdy; aslbl.bottom += sdy;
-            s.draw_label(hdc, aslbl, L"Live preview");
-
             RECT preview = p->rects.analog_preview;
-            preview.top += sdy; preview.bottom += sdy;
+
+            // Draw scrollable settings clipped to exclude the sticky preview region
+            {
+                int sdc2 = SaveDC(hdc);
+                ExcludeClipRect(hdc, preview.left, preview.top, preview.right, preview.bottom);
+
+                RECT min_r = p->rects.analog_min_ticks;
+                min_r.top += sdy; min_r.bottom += sdy;
+                paint_option_btn(hdc, min_r,
+                                 p->analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
+                                 p->analog_style.show_minute_ticks, s);
+
+                RECT hrlbl = map_dlu(dlg, 158, 82, 80, 8);
+                hrlbl.top += sdy; hrlbl.bottom += sdy;
+                s.draw_label(hdc, hrlbl, L"Hour labels");
+
+                const wchar_t* lbl_names[] = {L"None", L"Sparse", L"Full"};
+                for (int i = 0; i < 3; ++i) {
+                    RECT ar = p->rects.analog_labels[i];
+                    ar.top += sdy; ar.bottom += sdy;
+                    paint_option_btn(hdc, ar, lbl_names[i],
+                                     (int)p->analog_style.hour_labels == i, s);
+                }
+
+                RECT color_lbl = map_dlu(dlg, 158, 112, 80, 8);
+                color_lbl.top += sdy; color_lbl.bottom += sdy;
+                s.draw_label(hdc, color_lbl, L"Colors");
+                for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
+                    RECT r = p->rects.analog_colors[i];
+                    r.top += sdy; r.bottom += sdy;
+                    int* field = analog_color_field(p->analog_style, i);
+                    bool custom = field && *field >= 0;
+                    paint_option_btn(hdc, r, analog_color_label(i), custom, s);
+                    RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
+                    COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
+                    GdiObj br{CreateSolidBrush(sw_color)};
+                    FillRect(hdc, &sw, (HBRUSH)br.h);
+                }
+
+                RECT value_lbl = map_dlu(dlg, 68, 248, 200, 8);
+                value_lbl.top += sdy; value_lbl.bottom += sdy;
+                s.draw_label(hdc, value_lbl, L"Size and opacity");
+                for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
+                    RECT r = p->rects.analog_values[i];
+                    r.top += sdy; r.bottom += sdy;
+                    int* field = analog_value_field(p->analog_style, i);
+                    wchar_t buf[96];
+                    wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
+                    paint_option_btn(hdc, r, buf, false, s);
+                }
+
+                RestoreDC(hdc, sdc2);
+            }
+
+            // Fixed preview drawn on top — no sdy offset
+            RECT prev_lbl = map_dlu(dlg, 68, 48, 80, 8);
+            s.draw_label(hdc, prev_lbl, L"Live preview");
             draw_analog_clock(hdc, preview, p->analog_style, *s.theme, s.dpi, 10, 10, 30);
-
-            RECT min_r = p->rects.analog_min_ticks;
-            min_r.top += sdy; min_r.bottom += sdy;
-            paint_option_btn(hdc, min_r,
-                             p->analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
-                             p->analog_style.show_minute_ticks, s);
-
-            RECT hrlbl = map_dlu(dlg, 154, 84, 70, 8);
-            hrlbl.top += sdy; hrlbl.bottom += sdy;
-            s.draw_label(hdc, hrlbl, L"Hour labels");
-
-            const wchar_t* lbl_names[] = {L"None", L"Sparse", L"Full"};
-            for (int i = 0; i < 3; ++i) {
-                RECT ar = p->rects.analog_labels[i];
-                ar.top += sdy; ar.bottom += sdy;
-                paint_option_btn(hdc, ar, lbl_names[i],
-                                 (int)p->analog_style.hour_labels == i, s);
-            }
-
-            RECT color_lbl = map_dlu(dlg, 154, 114, 70, 8);
-            color_lbl.top += sdy; color_lbl.bottom += sdy;
-            s.draw_label(hdc, color_lbl, L"Colors");
-            for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
-                RECT r = p->rects.analog_colors[i];
-                r.top += sdy; r.bottom += sdy;
-                int* field = analog_color_field(p->analog_style, i);
-                bool custom = field && *field >= 0;
-                paint_option_btn(hdc, r, analog_color_label(i), custom, s);
-                RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
-                COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
-                GdiObj br{CreateSolidBrush(sw_color)};
-                FillRect(hdc, &sw, (HBRUSH)br.h);
-            }
-
-            RECT value_lbl = map_dlu(dlg, 72, 246, 90, 8);
-            value_lbl.top += sdy; value_lbl.bottom += sdy;
-            s.draw_label(hdc, value_lbl, L"Size and opacity");
-            for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
-                RECT r = p->rects.analog_values[i];
-                r.top += sdy; r.bottom += sdy;
-                int* field = analog_value_field(p->analog_style, i);
-                wchar_t buf[96];
-                wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
-                paint_option_btn(hdc, r, buf, false, s);
-            }
         }
 
     } else if (p->active_tab == TAB_TIMERS) {
@@ -388,11 +447,17 @@ static INT_PTR on_ctl_color(HWND dlg, UINT msg, HDC hdc) {
 }
 
 static INT_PTR on_nc_hit_test(HWND dlg, LPARAM lp) {
-    RECT title_rc = {0, 0, DLG_W, TITLE_H + 2};
-    MapDialogRect(dlg, &title_rc);
+    RECT rc{};
+    GetClientRect(dlg, &rc);
+    RECT title_h{0, 0, 0, TITLE_H + 2};
+    MapDialogRect(dlg, &title_h);
     POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
     ScreenToClient(dlg, &pt);
-    return (pt.y >= 0 && pt.y < title_rc.bottom) ? HTCAPTION : FALSE;
+    if (pt.x >= 0 && pt.x < rc.right && pt.y >= 0 && pt.y < title_h.bottom) {
+        SetWindowLongPtrW(dlg, DWLP_MSGRESULT, HTCAPTION);
+        return TRUE;
+    }
+    return FALSE;
 }
 
 static INT_PTR on_draw_item(HWND dlg, LPARAM lp) {
@@ -616,6 +681,8 @@ static INT_PTR on_key_down(HWND dlg, WPARAM wp) {
 static INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
     switch (msg) {
     case WM_INITDIALOG:       return on_init(dlg, lp);
+    case WM_SIZE:             return on_resize(dlg, wp);
+    case WM_GETMINMAXINFO:    return on_get_min_max_info(dlg, lp);
     case WM_ERASEBKGND:       return on_erase_background(dlg, (HDC)wp);
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLOREDIT:

--- a/src/ui_windows_settings_dialog_ids.hpp
+++ b/src/ui_windows_settings_dialog_ids.hpp
@@ -31,7 +31,7 @@ constexpr WORD CLS_EDIT     = 0x0081;
 constexpr WORD CLS_STATIC   = 0x0082;
 constexpr WORD CLS_COMBOBOX = 0x0085;
 
-constexpr short DLG_W = 240, DLG_H = 156;
+constexpr short DLG_W = 290, DLG_H = 185;
 constexpr short SIDEBAR_W = 62;
 constexpr short TITLE_H = 18;
 

--- a/src/ui_windows_settings_dialog_scroll.hpp
+++ b/src/ui_windows_settings_dialog_scroll.hpp
@@ -1,5 +1,23 @@
 // Included by ui_windows.hpp inside namespace settings_dlg.
 
+// Returns the pixel y where the scrollable content area ends (top of button row).
+static int content_area_bottom(HWND dlg) {
+    HWND ok_btn = GetDlgItem(dlg, IDC_SET_OK);
+    if (ok_btn) {
+        RECT r{};
+        GetWindowRect(ok_btn, &r);
+        MapWindowPoints(HWND_DESKTOP, dlg, reinterpret_cast<POINT*>(&r), 2);
+        if (r.top > 0) {
+            RECT margin{0, 0, 0, 4};
+            MapDialogRect(dlg, &margin);
+            return r.top - margin.bottom;
+        }
+    }
+    RECT r{0, 0, 0, DLG_H - 24};
+    MapDialogRect(dlg, &r);
+    return r.bottom;
+}
+
 static void set_pomo_visible(HWND dlg, bool show) {
     int cmd = show ? SW_SHOW : SW_HIDE;
     for (int id = IDC_POMO_WORK; id <= IDC_MIN_CADENCE; ++id) {
@@ -55,8 +73,8 @@ static int tab_painted_content_bottom(HWND dlg, const Params& p) {
         if (p.clock_view != ClockView::Analog) {
             return map_dlu(dlg, 70, 28, 80, 12).bottom;
         }
+        // analog_preview is fixed/sticky and excluded from scroll content
         int bottom = std::max({
-            rect_bottom_after_scroll(p.rects.analog_preview, p),
             rect_bottom_after_scroll(p.rects.analog_min_ticks, p),
             rect_bottom_after_scroll(p.rects.analog_labels[0], p),
             rect_bottom_after_scroll(p.rects.analog_labels[1], p),
@@ -104,11 +122,9 @@ static void update_content_scroll(HWND dlg, Params* p) {
     position_scrollable_controls(dlg, *p);
 
     RECT div_top = {0, 0, 0, TITLE_H + 2};
-    RECT div_bot = {0, 0, 0, 132};
     MapDialogRect(dlg, &div_top);
-    MapDialogRect(dlg, &div_bot);
 
-    int view_h = div_bot.bottom - div_top.bottom;
+    int view_h = content_area_bottom(dlg) - div_top.bottom;
     int content_bottom = std::max(visible_child_content_bottom(dlg), tab_painted_content_bottom(dlg, *p));
     int content_h = std::max(0, content_bottom - (int)div_top.bottom);
     int max_scroll = std::max(0, content_h - view_h);

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -34,15 +34,16 @@ static HitRects compute_rects(HWND dlg) {
     h.theme[2] = map_dlu(dlg, 70, 72, 54, 13);
 
     // Analog settings sit below the format dropdown (which is at y=40, h=12).
-    h.analog_preview = map_dlu(dlg, 72, 58, 72, 72);
-    h.analog_min_ticks = map_dlu(dlg, 154,  64, 68, 12);
-    h.analog_labels[0] = map_dlu(dlg, 154,  94, 24, 12);
-    h.analog_labels[1] = map_dlu(dlg, 180, 94, 26, 12);
-    h.analog_labels[2] = map_dlu(dlg, 208, 94, 24, 12);
+    // Preview is fixed (sticky) at y=58; right column starts at x=158.
+    h.analog_preview = map_dlu(dlg, 68, 58, 80, 80);
+    h.analog_min_ticks = map_dlu(dlg, 158,  64, 122, 12);
+    h.analog_labels[0] = map_dlu(dlg, 158,  92,  40, 12);
+    h.analog_labels[1] = map_dlu(dlg, 202,  92,  40, 12);
+    h.analog_labels[2] = map_dlu(dlg, 246,  92,  40, 12);
     for (int i = 0; i < ANALOG_COLOR_COUNT; ++i)
-        h.analog_colors[i] = map_dlu(dlg, 154, (short)(124 + i * 14), 70, 12);
+        h.analog_colors[i] = map_dlu(dlg, 158, (short)(122 + i * 14), 122, 12);
     for (int i = 0; i < ANALOG_VALUE_COUNT; ++i)
-        h.analog_values[i] = map_dlu(dlg, 72, (short)(256 + i * 14), 152, 12);
+        h.analog_values[i] = map_dlu(dlg, 68, (short)(258 + i * 14), 214, 12);
 
     h.sound      = map_dlu(dlg, 70,  97, 100, 13);
     h.auto_start = map_dlu(dlg, 70, 115, 100, 13);

--- a/src/ui_windows_settings_dialog_template.hpp
+++ b/src/ui_windows_settings_dialog_template.hpp
@@ -27,7 +27,7 @@ constexpr WORD CTRL_COUNT = 25;
 
 static std::vector<WORD> build_template() {
     Buf b;
-    b.push_dword(WS_POPUP | WS_BORDER | WS_VSCROLL);
+    b.push_dword(WS_POPUP | WS_THICKFRAME | WS_VSCROLL);
     b.push_dword(0);
     b.push_word(CTRL_COUNT);
     b.push_word(0); b.push_word(0);
@@ -90,13 +90,13 @@ static std::vector<WORD> build_template() {
 
     // Clock format dropdown — height includes dropdown list space for 5 items
     add_item(b, CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP, 0,
-             68, 40, 162, 80, IDC_CLOCK_COMBO, CLS_COMBOBOX, L"");
+             68, 40, 212, 80, IDC_CLOCK_COMBO, CLS_COMBOBOX, L"");
 
     short btn_w = 44, btn_h = 16, btn_gap = 8;
     short content_cx = DLG_W - SIDEBAR_W - 4;
     short total_bw = 2 * btn_w + btn_gap;
     short btn_x0 = SIDEBAR_W + 2 + (content_cx - total_bw) / 2;
-    short btn_y = 138;
+    short btn_y = DLG_H - 24;
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
              btn_x0, btn_y, btn_w, btn_h, IDC_SET_OK, CLS_BUTTON, L"Apply");
     add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,


### PR DESCRIPTION
Closes #320

## Summary

- **Wider dialog**: DLG_W 240→290 DLU, DLG_H 156→185 DLU — more breathing room between the preview and the right-column controls; the values section spans the full content width (x=68, w=214).
- **Sticky analog preview**: the live clock preview is now drawn at a fixed position. All other settings (min ticks, hour labels, colors, size/opacity) scroll underneath it. `ExcludeClipRect` prevents scrolled content from overpainting the preview area.
- **Resizable**: `WS_BORDER` replaced by `WS_THICKFRAME` — the dialog now has a sizing border. `WM_SIZE` repositions the Apply/Cancel buttons to track the dialog bottom dynamically. `WM_GETMINMAXINFO` enforces a sensible minimum size.
- **Movable**: fixed `WM_NCHITTEST` to set `DWLP_MSGRESULT = HTCAPTION` and return `TRUE` (the old code returned `HTCAPTION` as the DlgProc return value which is not the correct contract); the title bar now correctly enables dragging.
- **Dynamic scroll range**: replaced the hardcoded 132 DLU constant with `content_area_bottom()` which queries the Apply button's current position, so the scrollable area always fills correctly regardless of dialog height.

## Test plan

- [ ] Open settings → Clock tab → select Analog
- [ ] Scroll down through colors/size settings — verify the live preview stays pinned at the top-left
- [ ] Drag the dialog by its title bar — confirm it moves
- [ ] Resize the dialog — confirm Apply/Cancel track the bottom edge, content scrolls correctly, and the minimum size is enforced
- [ ] Apply/Cancel buttons work normally on both Analog and non-Analog clock views
- [ ] All other settings tabs (Appearance, Pomodoro, Timers) unaffected

https://claude.ai/code/session_01KWW3YXNfkupQJJEfdEUK1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWW3YXNfkupQJJEfdEUK1f)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable settings dialog with minimum-size enforcement and automatic button repositioning.
  * Sticky live analog-preview area separated from scrollable settings for clearer live feedback.

* **Bug Fixes**
  * Fixed scrollbar range and content clipping so controls align with the action button row.
  * Improved title-area hit detection for more reliable window interactions.

* **Style**
  * Increased dialog dimensions and updated frame behavior; widened certain controls for better layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/329)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->