### PR TITLE
feat: Alarms (issue #330)

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -26,7 +26,11 @@ enum Act {
     A_CLK_CYCLE,
     A_TMR_RST_ALL,
     A_SETTINGS,
-    A_TMR_BASE = 100,
+    A_SHOW_ALARMS,
+    A_ALARM_ADD,
+    A_TMR_BASE    = 100,
+    A_ALARM_DEL   = 500,  // A_ALARM_DEL + i to delete alarm i
+    A_ALARM_TOGGLE = 520, // A_ALARM_TOGGLE + i to enable/disable alarm i
 };
 
 constexpr int TMR_STRIDE = 12;
@@ -84,6 +88,8 @@ inline bool wants_blink(int act) {
     case A_SHOW_CLK:
     case A_SHOW_SW:
     case A_SHOW_TMR:
+    case A_SHOW_ALARMS:
+    case A_ALARM_ADD:
     case A_SW_START:
     case A_SW_COPY:
     case A_THEME:
@@ -91,7 +97,9 @@ inline bool wants_blink(int act) {
     case A_SETTINGS:
         return false;
     default:
-        if (act >= A_TMR_BASE) {
+        if (act >= A_ALARM_DEL && act < A_ALARM_DEL + ALARM_MAX_COUNT) return false;
+        if (act >= A_ALARM_TOGGLE && act < A_ALARM_TOGGLE + ALARM_MAX_COUNT) return false;
+        if (act >= A_TMR_BASE && act < A_ALARM_DEL) {
             int off = (act - A_TMR_BASE) % TMR_STRIDE;
             if (off == A_TMR_START || off == A_TMR_ADD || off == A_TMR_DEL) return false;
         }
@@ -107,6 +115,7 @@ struct HandleResult {
     bool copy_laps = false;
     bool apply_theme = false;
     bool open_settings = false;
+    bool open_alarm_dialog = false;
 };
 
 inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock::time_point now,
@@ -200,6 +209,14 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
     case A_SETTINGS:
         r.open_settings = true;
         break;
+    case A_SHOW_ALARMS:
+        app.show_alarms = !app.show_alarms;
+        r.resize = true;
+        r.save_config = true;
+        break;
+    case A_ALARM_ADD:
+        r.open_alarm_dialog = true;
+        break;
     case A_TMR_RST_ALL:
         for (auto& ts : app.timers) {
             ts.notified = false;
@@ -215,7 +232,22 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         r.save_config = true;
         break;
     default:
-        if (act >= A_TMR_BASE) {
+        if (act >= A_ALARM_DEL && act < A_ALARM_DEL + ALARM_MAX_COUNT) {
+            int i = act - A_ALARM_DEL;
+            if (i >= 0 && i < (int)app.alarms.size()) {
+                app.alarms.erase(app.alarms.begin() + i);
+                if (i < (int)app.alarm_notified.size())
+                    app.alarm_notified.erase(app.alarm_notified.begin() + i);
+                r.resize = true;
+                r.save_config = true;
+            }
+        } else if (act >= A_ALARM_TOGGLE && act < A_ALARM_TOGGLE + ALARM_MAX_COUNT) {
+            int i = act - A_ALARM_TOGGLE;
+            if (i >= 0 && i < (int)app.alarms.size()) {
+                app.alarms[i].enabled = !app.alarms[i].enabled;
+                r.save_config = true;
+            }
+        } else if (act >= A_TMR_BASE) {
             int idx = (act - A_TMR_BASE) / TMR_STRIDE;
             int off = (act - A_TMR_BASE) % TMR_STRIDE;
             if (idx < 0 || idx >= (int)app.timers.size()) break;

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -236,8 +236,6 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
             int i = act - A_ALARM_DEL;
             if (i >= 0 && i < (int)app.alarms.size()) {
                 app.alarms.erase(app.alarms.begin() + i);
-                if (i < (int)app.alarm_notified.size())
-                    app.alarm_notified.erase(app.alarm_notified.begin() + i);
                 r.resize = true;
                 r.save_config = true;
             }

--- a/src/alarm.hpp
+++ b/src/alarm.hpp
@@ -24,4 +24,5 @@ struct Alarm {
     int date_year = 2026, date_month = 1, date_day = 1;
     int hour = 8, minute = 0;
     bool enabled = true;
+    bool notified = false;  // runtime-only, not persisted; reset each minute by check_alarms
 };

--- a/src/alarm.hpp
+++ b/src/alarm.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <string>
+
+// Day bitmask: bit 0 = Monday, bit 1 = Tuesday, ..., bit 6 = Sunday
+inline constexpr int ALARM_DAY_MON = 1 << 0;
+inline constexpr int ALARM_DAY_TUE = 1 << 1;
+inline constexpr int ALARM_DAY_WED = 1 << 2;
+inline constexpr int ALARM_DAY_THU = 1 << 3;
+inline constexpr int ALARM_DAY_FRI = 1 << 4;
+inline constexpr int ALARM_DAY_SAT = 1 << 5;
+inline constexpr int ALARM_DAY_SUN = 1 << 6;
+inline constexpr int ALARM_ALL_DAYS = 0x7F;
+inline constexpr int ALARM_WEEKDAYS = 0x1F;
+inline constexpr int ALARM_WEEKEND  = 0x60;
+
+inline constexpr int ALARM_MAX_COUNT = 20;
+
+enum class AlarmSchedule { Days = 0, Date = 1 };
+
+struct Alarm {
+    std::string name;
+    AlarmSchedule schedule = AlarmSchedule::Days;
+    int days_mask = ALARM_ALL_DAYS;
+    int date_year = 2026, date_month = 1, date_day = 1;
+    int hour = 8, minute = 0;
+    bool enabled = true;
+};

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include "alarm.hpp"
 #include "dialog_style.hpp"
+#include "encoding.hpp"
 
 namespace alarm_dlg {
 
@@ -172,7 +173,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
 
         // Populate edits
         const auto& a = p->result;
-        std::wstring name_w(a.name.begin(), a.name.end());
+        std::wstring name_w = utf8_to_wide(a.name);
         SetDlgItemTextW(dlg, IDC_ALM_NAME, name_w.c_str());
         SendDlgItemMessageW(dlg, IDC_ALM_NAME, EM_SETLIMITTEXT, 40, 0);
         SetDlgItemTextW(dlg, IDC_ALM_HOUR, std::format(L"{:02}", a.hour).c_str());
@@ -332,7 +333,7 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             // Collect name
             wchar_t nbuf[48] = {};
             GetDlgItemTextW(dlg, IDC_ALM_NAME, nbuf, 47);
-            p->result.name = std::string(nbuf, nbuf + wcslen(nbuf));
+            p->result.name = wide_to_utf8(nbuf);
 
             // Hour
             wchar_t hbuf[4] = {};
@@ -368,6 +369,13 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
                 if (yr < 2000 || yr > 9999 || mo < 1 || mo > 12 || dy < 1 || dy > 31) {
                     MessageBeep(MB_ICONASTERISK);
                     SetFocus(GetDlgItem(dlg, IDC_ALM_YEAR));
+                    return TRUE;
+                }
+                SYSTEMTIME st_check{(WORD)yr, (WORD)mo, 0, (WORD)dy, 0, 0, 0, 0};
+                FILETIME ft_check;
+                if (!SystemTimeToFileTime(&st_check, &ft_check)) {
+                    MessageBeep(MB_ICONASTERISK);
+                    SetFocus(GetDlgItem(dlg, IDC_ALM_DAY));
                     return TRUE;
                 }
                 p->result.date_year  = (int)yr;

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -1,0 +1,429 @@
+#pragma once
+#include <windows.h>
+#include <windowsx.h>
+#include <format>
+#include <string>
+#include "alarm.hpp"
+#include "dialog_style.hpp"
+
+namespace alarm_dlg {
+
+// ─── Control IDs ─────────────────────────────────────────────────────────────
+
+constexpr WORD IDC_ALM_NAME   = 401;
+constexpr WORD IDC_ALM_HOUR   = 402;
+constexpr WORD IDC_ALM_MIN    = 403;
+constexpr WORD IDC_ALM_YEAR   = 404;
+constexpr WORD IDC_ALM_MONTH  = 405;
+constexpr WORD IDC_ALM_DAY    = 406;
+constexpr WORD IDC_ALM_OK     = 407;
+constexpr WORD IDC_ALM_CANCEL = 408;
+
+constexpr WORD CLS_BUTTON  = 0x0080;
+constexpr WORD CLS_EDIT    = 0x0081;
+constexpr WORD CLS_STATIC  = 0x0082;
+
+// Dialog dimensions (DLU)
+constexpr short DLG_W = 200, DLG_H = 138;
+constexpr WORD  CTRL_COUNT = 8;
+
+// ─── Layout helpers ───────────────────────────────────────────────────────────
+
+struct Params {
+    Alarm result;
+    DlgStyle style;
+    // Painted-control rects (pixels, set in WM_INITDIALOG via MapDialogRect)
+    RECT rc_days_btn{};
+    RECT rc_date_btn{};
+    RECT rc_day[7]{};  // Mon-Sun painted toggles
+};
+
+// ─── Template builder ─────────────────────────────────────────────────────────
+
+struct Buf {
+    std::vector<WORD> data;
+    void align4() { while (data.size() % 2) data.push_back(0); }
+    void push_word(WORD w)   { data.push_back(w); }
+    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
+    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
+    void push_wstr_empty() { data.push_back(0); }
+};
+
+inline void add_item(Buf& b, DWORD style, short x, short y, short cx, short cy,
+                     WORD id, WORD cls_atom, const wchar_t* title) {
+    b.align4();
+    b.push_dword(WS_CHILD | WS_VISIBLE | style);
+    b.push_dword(0); // exStyle
+    b.push_word((WORD)x); b.push_word((WORD)y);
+    b.push_word((WORD)cx); b.push_word((WORD)cy);
+    b.push_word(id);
+    b.push_word(0xFFFF); b.push_word(cls_atom);
+    b.push_wstr(title);
+    b.push_word(0);
+}
+
+inline std::vector<WORD> build_template() {
+    Buf b;
+    b.push_dword(WS_POPUP | WS_BORDER);
+    b.push_dword(0);
+    b.push_word(CTRL_COUNT);
+    b.push_word(0); b.push_word(0);
+    b.push_word(DLG_W); b.push_word(DLG_H);
+    b.push_wstr_empty(); // menu
+    b.push_wstr_empty(); // class
+    b.push_wstr_empty(); // caption (painted)
+
+    // Name edit  (x=46 y=25 w=148 h=11)
+    add_item(b, ES_AUTOHSCROLL | WS_TABSTOP, 46, 25, 148, 11, IDC_ALM_NAME, CLS_EDIT, L"");
+    // Hour edit  (x=46 y=40 w=22 h=11)
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 46, 40, 22, 11, IDC_ALM_HOUR, CLS_EDIT, L"");
+    // Min edit   (x=78 y=40 w=22 h=11)
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 78, 40, 22, 11, IDC_ALM_MIN,  CLS_EDIT, L"");
+
+    // Date fields: Year (x=36 y=70 w=38 h=11), Month (x=104 y=70 w=22 h=11), Day (x=158 y=70 w=22 h=11)
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 36, 70, 38, 11, IDC_ALM_YEAR,  CLS_EDIT, L"");
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 104, 70, 22, 11, IDC_ALM_MONTH, CLS_EDIT, L"");
+    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 158, 70, 22, 11, IDC_ALM_DAY,   CLS_EDIT, L"");
+
+    // OK / Cancel (owner-draw)
+    constexpr short btn_w = 44, btn_h = 16;
+    constexpr short btn_y = 118;
+    constexpr short btn_x0 = (DLG_W - 2 * btn_w - 8) / 2;
+    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0, btn_y, btn_w, btn_h, IDC_ALM_OK,     CLS_BUTTON, L"OK");
+    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0 + btn_w + 8, btn_y, btn_w, btn_h, IDC_ALM_CANCEL, CLS_BUTTON, L"Cancel");
+
+    return b.data;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+static RECT map_dlu(HWND dlg, short x, short y, short cx, short cy) {
+    RECT r = {x, y, x + cx, y + cy};
+    MapDialogRect(dlg, &r);
+    return r;
+}
+
+static void show_date_controls(HWND dlg, bool show) {
+    int cmd = show ? SW_SHOW : SW_HIDE;
+    for (WORD id : {IDC_ALM_YEAR, IDC_ALM_MONTH, IDC_ALM_DAY})
+        if (HWND h = GetDlgItem(dlg, id)) ShowWindow(h, cmd);
+}
+
+static void init_painted_rects(HWND dlg, Params& p) {
+    // Days / Date toggle buttons (painted)
+    p.rc_days_btn = map_dlu(dlg, 8,  56, 44, 13);
+    p.rc_date_btn = map_dlu(dlg, 56, 56, 44, 13);
+
+    // Day toggles (Mon=bit0 .. Sun=bit6): row1 Mon-Fri, row2 Sat-Sun
+    // Row 1: Mon Tue Wed Thu Fri (x=8,36,64,92,120  y=72  w=26 h=13)
+    // Row 2: Sat Sun             (x=8,36              y=87  w=26 h=13)
+    static constexpr short xs[] = {8, 36, 64, 92, 120, 8, 36};
+    static constexpr short ys[] = {72,72,72, 72,  72, 87, 87};
+    for (int i = 0; i < 7; ++i)
+        p.rc_day[i] = map_dlu(dlg, xs[i], ys[i], 26, 13);
+}
+
+static void paint_toggle_btn(HDC hdc, const RECT& r, const wchar_t* text, bool active,
+                              const DlgStyle& s) {
+    int rr = s.scale(4);
+    HBRUSH br = CreateSolidBrush(active ? s.theme->active : s.theme->btn);
+    HPEN   pn = CreatePen(PS_NULL, 0, 0);
+    auto* obr = (HBRUSH)SelectObject(hdc, br);
+    auto* opn = (HPEN)SelectObject(hdc, pn);
+    RoundRect(hdc, r.left, r.top, r.right, r.bottom, rr, rr);
+    SelectObject(hdc, obr); SelectObject(hdc, opn);
+    DeleteObject(br); DeleteObject(pn);
+    SetBkMode(hdc, TRANSPARENT);
+    SetTextColor(hdc, s.theme->text);
+    SelectObject(hdc, s.font);
+    RECT rc = r;
+    DrawTextW(hdc, text, -1, &rc, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+}
+
+// ─── Dialog procedure ─────────────────────────────────────────────────────────
+
+inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
+    auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
+
+    switch (msg) {
+    case WM_INITDIALOG: {
+        p = reinterpret_cast<Params*>(lp);
+        SetWindowLongPtrW(dlg, DWLP_USER, (LONG_PTR)p);
+        p->style.apply_dark_mode(dlg);
+
+        // Centre on parent
+        if (HWND par = GetParent(dlg)) {
+            RECT pr, dr;
+            GetWindowRect(par, &pr); GetWindowRect(dlg, &dr);
+            int dw = dr.right - dr.left, dh = dr.bottom - dr.top;
+            SetWindowPos(dlg, nullptr,
+                         pr.left + (pr.right - pr.left - dw) / 2,
+                         pr.top  + (pr.bottom - pr.top  - dh) / 2,
+                         0, 0, SWP_NOSIZE | SWP_NOZORDER);
+        }
+
+        init_painted_rects(dlg, *p);
+
+        // Set fonts on all children
+        EnumChildWindows(dlg, [](HWND ch, LPARAM par) -> BOOL {
+            SendMessageW(ch, WM_SETFONT, (WPARAM)((Params*)par)->style.font, FALSE);
+            return TRUE;
+        }, (LPARAM)p);
+
+        // Populate edits
+        const auto& a = p->result;
+        std::wstring name_w(a.name.begin(), a.name.end());
+        SetDlgItemTextW(dlg, IDC_ALM_NAME, name_w.c_str());
+        SendDlgItemMessageW(dlg, IDC_ALM_NAME, EM_SETLIMITTEXT, 40, 0);
+        SetDlgItemTextW(dlg, IDC_ALM_HOUR, std::format(L"{:02}", a.hour).c_str());
+        SetDlgItemTextW(dlg, IDC_ALM_MIN,  std::format(L"{:02}", a.minute).c_str());
+        SendDlgItemMessageW(dlg, IDC_ALM_HOUR, EM_SETLIMITTEXT, 2, 0);
+        SendDlgItemMessageW(dlg, IDC_ALM_MIN,  EM_SETLIMITTEXT, 2, 0);
+
+        SetDlgItemTextW(dlg, IDC_ALM_YEAR,  std::format(L"{}", a.date_year).c_str());
+        SetDlgItemTextW(dlg, IDC_ALM_MONTH, std::format(L"{:02}", a.date_month).c_str());
+        SetDlgItemTextW(dlg, IDC_ALM_DAY,   std::format(L"{:02}", a.date_day).c_str());
+        SendDlgItemMessageW(dlg, IDC_ALM_YEAR,  EM_SETLIMITTEXT, 4, 0);
+        SendDlgItemMessageW(dlg, IDC_ALM_MONTH, EM_SETLIMITTEXT, 2, 0);
+        SendDlgItemMessageW(dlg, IDC_ALM_DAY,   EM_SETLIMITTEXT, 2, 0);
+
+        // Show/hide date fields based on schedule type
+        bool is_date = (a.schedule == AlarmSchedule::Date);
+        show_date_controls(dlg, is_date);
+
+        SetFocus(GetDlgItem(dlg, IDC_ALM_NAME));
+        return FALSE;
+    }
+
+    case WM_ERASEBKGND: {
+        if (!p) return FALSE;
+        HDC hdc = (HDC)wp;
+        RECT rc; GetClientRect(dlg, &rc);
+        p->style.fill_background(hdc, rc);
+
+        // Title
+        RECT title_dlu = {0, 0, DLG_W, 20};
+        MapDialogRect(dlg, &title_dlu);
+        title_dlu.right = rc.right;
+        p->style.draw_label(hdc, title_dlu, L"Add Alarm", DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+
+        // Divider under title
+        HPEN pen = CreatePen(PS_SOLID, 1, p->style.theme->divider);
+        auto* op = (HPEN)SelectObject(hdc, pen);
+        RECT div = {0, 0, 0, 21}; MapDialogRect(dlg, &div);
+        MoveToEx(hdc, 0, div.bottom, nullptr);
+        LineTo(hdc, rc.right, div.bottom);
+        SelectObject(hdc, op); DeleteObject(pen);
+
+        // Field labels
+        auto lbl = [&](short x, short y, short cx, short cy, const wchar_t* t) {
+            RECT r = {x, y, x + cx, y + cy}; MapDialogRect(dlg, &r);
+            p->style.draw_label(hdc, r, t);
+        };
+        lbl(8, 25, 36, 11, L"Name:");
+        lbl(8, 40, 36, 11, L"Time:");
+        RECT colon = {70, 40, 76, 51}; MapDialogRect(dlg, &colon);
+        p->style.draw_label(hdc, colon, L":", DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        lbl(8, 56, 36, 11, L"Schedule:");
+
+        // Days / Date toggle buttons (painted)
+        bool is_days = (p->result.schedule == AlarmSchedule::Days);
+        paint_toggle_btn(hdc, p->rc_days_btn, L"Days", is_days,  p->style);
+        paint_toggle_btn(hdc, p->rc_date_btn, L"Date", !is_days, p->style);
+
+        if (is_days) {
+            // Paint Mon–Sun toggle buttons
+            static constexpr const wchar_t* day_names[] = {
+                L"Mon", L"Tue", L"Wed", L"Thu", L"Fri", L"Sat", L"Sun"
+            };
+            for (int i = 0; i < 7; ++i) {
+                bool on = (p->result.days_mask & (1 << i)) != 0;
+                paint_toggle_btn(hdc, p->rc_day[i], day_names[i], on, p->style);
+            }
+        } else {
+            // Paint date labels (the edits sit beside them)
+            lbl(8,   70, 26, 11, L"Year:");
+            lbl(80,  70, 22, 11, L"Mo:");
+            lbl(134, 70, 22, 11, L"Dy:");
+        }
+
+        return 1;
+    }
+
+    case WM_CTLCOLORSTATIC: {
+        if (!p) break;
+        HDC hdc = (HDC)wp;
+        SetTextColor(hdc, p->style.theme->text);
+        SetBkMode(hdc, TRANSPARENT);
+        static HBRUSH s_bg = nullptr;
+        if (s_bg) DeleteObject(s_bg);
+        s_bg = CreateSolidBrush(p->style.theme->bg);
+        return (INT_PTR)s_bg;
+    }
+    case WM_CTLCOLOREDIT: {
+        if (!p) break;
+        HDC hdc = (HDC)wp;
+        SetTextColor(hdc, p->style.theme->text);
+        SetBkColor(hdc, p->style.theme->bar);
+        static HBRUSH s_edit_bg = nullptr;
+        if (s_edit_bg) DeleteObject(s_edit_bg);
+        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
+        return (INT_PTR)s_edit_bg;
+    }
+    case WM_CTLCOLORBTN: {
+        if (!p) break;
+        static HBRUSH s_btn_bg = nullptr;
+        if (s_btn_bg) DeleteObject(s_btn_bg);
+        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
+        return (INT_PTR)s_btn_bg;
+    }
+
+    case WM_NCHITTEST: {
+        RECT title = {0, 0, DLG_W, 21}; MapDialogRect(dlg, &title);
+        POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        ScreenToClient(dlg, &pt);
+        if (pt.y >= 0 && pt.y < title.bottom) return HTCAPTION;
+        break;
+    }
+
+    case WM_LBUTTONDOWN: {
+        if (!p) break;
+        POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        bool was_days = (p->result.schedule == AlarmSchedule::Days);
+
+        if (PtInRect(&p->rc_days_btn, pt) && !was_days) {
+            p->result.schedule = AlarmSchedule::Days;
+            show_date_controls(dlg, false);
+            InvalidateRect(dlg, nullptr, TRUE);
+            return TRUE;
+        }
+        if (PtInRect(&p->rc_date_btn, pt) && was_days) {
+            p->result.schedule = AlarmSchedule::Date;
+            show_date_controls(dlg, true);
+            InvalidateRect(dlg, nullptr, TRUE);
+            return TRUE;
+        }
+        if (was_days) {
+            for (int i = 0; i < 7; ++i) {
+                if (PtInRect(&p->rc_day[i], pt)) {
+                    p->result.days_mask ^= (1 << i);
+                    InvalidateRect(dlg, nullptr, TRUE);
+                    return TRUE;
+                }
+            }
+        }
+        break;
+    }
+
+    case WM_DRAWITEM: {
+        if (!p) break;
+        auto* di = (DRAWITEMSTRUCT*)lp;
+        if (di->CtlType != ODT_BUTTON) break;
+        bool focused = (di->itemState & ODS_FOCUS) != 0;
+        const wchar_t* lbl = (di->CtlID == IDC_ALM_OK) ? L"OK" : L"Cancel";
+        p->style.draw_button(di->hDC, di->rcItem, lbl, focused);
+        return TRUE;
+    }
+
+    case WM_COMMAND: {
+        switch (LOWORD(wp)) {
+        case IDC_ALM_OK: {
+            if (!p) return TRUE;
+            // Collect name
+            wchar_t nbuf[48] = {};
+            GetDlgItemTextW(dlg, IDC_ALM_NAME, nbuf, 47);
+            p->result.name = std::string(nbuf, nbuf + wcslen(nbuf));
+
+            // Hour
+            wchar_t hbuf[4] = {};
+            GetDlgItemTextW(dlg, IDC_ALM_HOUR, hbuf, 3);
+            long hv = std::wcstol(hbuf, nullptr, 10);
+            if (hv < 0 || hv > 23) {
+                MessageBeep(MB_ICONASTERISK);
+                SetFocus(GetDlgItem(dlg, IDC_ALM_HOUR));
+                return TRUE;
+            }
+            p->result.hour = (int)hv;
+
+            // Minute
+            wchar_t mbuf[4] = {};
+            GetDlgItemTextW(dlg, IDC_ALM_MIN, mbuf, 3);
+            long mv = std::wcstol(mbuf, nullptr, 10);
+            if (mv < 0 || mv > 59) {
+                MessageBeep(MB_ICONASTERISK);
+                SetFocus(GetDlgItem(dlg, IDC_ALM_MIN));
+                return TRUE;
+            }
+            p->result.minute = (int)mv;
+
+            // Date fields (only when Date schedule)
+            if (p->result.schedule == AlarmSchedule::Date) {
+                wchar_t ybuf[8] = {}, mobuf[4] = {}, dbuf[4] = {};
+                GetDlgItemTextW(dlg, IDC_ALM_YEAR,  ybuf, 7);
+                GetDlgItemTextW(dlg, IDC_ALM_MONTH, mobuf, 3);
+                GetDlgItemTextW(dlg, IDC_ALM_DAY,   dbuf, 3);
+                long yr = std::wcstol(ybuf, nullptr, 10);
+                long mo = std::wcstol(mobuf, nullptr, 10);
+                long dy = std::wcstol(dbuf, nullptr, 10);
+                if (yr < 2000 || yr > 9999 || mo < 1 || mo > 12 || dy < 1 || dy > 31) {
+                    MessageBeep(MB_ICONASTERISK);
+                    SetFocus(GetDlgItem(dlg, IDC_ALM_YEAR));
+                    return TRUE;
+                }
+                p->result.date_year  = (int)yr;
+                p->result.date_month = (int)mo;
+                p->result.date_day   = (int)dy;
+            }
+
+            EndDialog(dlg, IDOK);
+            return TRUE;
+        }
+        case IDC_ALM_CANCEL:
+            EndDialog(dlg, IDCANCEL);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_KEYDOWN:
+        if (wp == VK_ESCAPE) { EndDialog(dlg, IDCANCEL); return TRUE; }
+        if (wp == VK_RETURN) { SendMessageW(dlg, WM_COMMAND, IDC_ALM_OK, 0); return TRUE; }
+        break;
+    }
+    return FALSE;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+inline bool show_add_alarm_dialog(HWND parent, Alarm& out, HFONT font,
+                                   const Theme* theme, int dpi) {
+    if (!theme) theme = &dark_theme;
+    if (dpi <= 0) dpi = STANDARD_DPI;
+
+    // Default to today's date for Date schedule
+    SYSTEMTIME st; GetLocalTime(&st);
+    Alarm defaults;
+    defaults.date_year  = st.wYear;
+    defaults.date_month = st.wMonth;
+    defaults.date_day   = st.wDay;
+
+    Params p{
+        .result = defaults,
+        .style  = {.theme = theme, .font = font, .dpi = dpi},
+    };
+
+    auto tmpl = build_template();
+    HINSTANCE hInst = (HINSTANCE)GetWindowLongPtrW(parent, GWLP_HINSTANCE);
+    INT_PTR res = DialogBoxIndirectParamW(
+        hInst,
+        reinterpret_cast<DLGTEMPLATE*>(tmpl.data()),
+        parent, DlgProc, (LPARAM)&p
+    );
+
+    if (res != IDOK) return false;
+    out = p.result;
+    out.enabled = true;
+    return true;
+}
+
+} // namespace alarm_dlg

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -53,7 +53,6 @@ struct App {
     std::vector<int> custom_preset_secs;
     bool show_alarms = false;
     std::vector<Alarm> alarms;
-    std::vector<bool> alarm_notified;  // parallel to alarms, reset each minute
     int alarm_notified_minute = -1;    // wall-clock minute (0–1439) when notified flags were last reset
     bool show_help = false;
     bool lap_write_failed = false;

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string>
 #include <vector>
+#include "alarm.hpp"
 #include "config.hpp"
 #include "stopwatch.hpp"
 #include "timer.hpp"
@@ -50,6 +51,10 @@ struct App {
     int pomodoro_cadence = POMODORO_DEFAULT_CADENCE;
     bool pomodoro_auto_start = true;
     std::vector<int> custom_preset_secs;
+    bool show_alarms = false;
+    std::vector<Alarm> alarms;
+    std::vector<bool> alarm_notified;  // parallel to alarms, reset each minute
+    int alarm_notified_minute = -1;    // wall-clock minute (0–1439) when notified flags were last reset
     bool show_help = false;
     bool lap_write_failed = false;
     int blink_act = 0;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <array>
 #include <string>
+#include <vector>
 
+#include "alarm.hpp"
 #include "pomodoro.hpp"
 
 enum class ThemeMode { Auto = 0, Light = 1, Dark = 2 };
@@ -83,6 +85,8 @@ struct Config {
     bool pomodoro_auto_start = true;
     ClockView clock_view = ClockView::H24_HMS;
     AnalogClockStyle analog_style;
+    bool show_alarms = false;
+    std::vector<Alarm> alarms;
     int num_custom_presets = 0;
     std::array<int, MAX_CUSTOM_PRESETS> custom_preset_secs{};
     Config() { timer_secs.fill(60); }

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -122,7 +122,6 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.show_tmr = cfg.show_tmr;
     s.app.show_alarms = cfg.show_alarms;
     s.app.alarms = cfg.alarms;
-    s.app.alarm_notified.assign(cfg.alarms.size(), false);
     s.app.alarm_notified_minute = -1;
     s.app.topmost = cfg.topmost;
     s.app.sound_on_expiry = cfg.sound_on_expiry;

--- a/src/config_io.hpp
+++ b/src/config_io.hpp
@@ -41,6 +41,8 @@ inline void save_config(HWND hwnd, const WndState& s) {
     cfg.clock_view = s.app.clock_view;
     cfg.show_sw = s.app.show_sw;
     cfg.show_tmr = s.app.show_tmr;
+    cfg.show_alarms = s.app.show_alarms;
+    cfg.alarms = s.app.alarms;
     cfg.topmost = s.app.topmost;
     cfg.sound_on_expiry = s.app.sound_on_expiry;
     cfg.theme_mode = s.app.theme_mode;
@@ -118,6 +120,10 @@ inline void load_config(HWND hwnd, WndState& s) {
     s.app.clock_view = cfg.clock_view;
     s.app.show_sw = cfg.show_sw;
     s.app.show_tmr = cfg.show_tmr;
+    s.app.show_alarms = cfg.show_alarms;
+    s.app.alarms = cfg.alarms;
+    s.app.alarm_notified.assign(cfg.alarms.size(), false);
+    s.app.alarm_notified_minute = -1;
     s.app.topmost = cfg.topmost;
     s.app.sound_on_expiry = cfg.sound_on_expiry;
     s.app.theme_mode = cfg.theme_mode;

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -282,5 +282,14 @@ inline bool config_read(Config& c, std::istream& f) {
         }
     }
     c.pos_valid = has_x && has_y && has_w;
+    for (auto& a : c.alarms) {
+        if (a.schedule == AlarmSchedule::Date) {
+            int yr = a.date_year, mo = a.date_month;
+            int max_day = 31;
+            if (mo == 4 || mo == 6 || mo == 9 || mo == 11) max_day = 30;
+            else if (mo == 2) max_day = (yr % 4 == 0 && (yr % 100 != 0 || yr % 400 == 0)) ? 29 : 28;
+            if (a.date_day > max_day) a.date_day = max_day;
+        }
+    }
     return true;
 }

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -14,6 +14,22 @@ inline bool config_write(const Config& c, std::ostream& f) {
     const char* theme_str = c.theme_mode == ThemeMode::Dark ? "dark" : c.theme_mode == ThemeMode::Light ? "light" : "auto";
     f << std::format("show_clk={}\nshow_sw={}\nshow_tmr={}\ntopmost={}\nsound_on_expiry={}\ntheme={}\nclock_view={}\nnum_timers={}\n", c.show_clk ? 1 : 0,
                      c.show_sw ? 1 : 0, c.show_tmr ? 1 : 0, c.topmost ? 1 : 0, c.sound_on_expiry ? 1 : 0, theme_str, (int)c.clock_view, c.num_timers);
+    if (c.show_alarms) f << "show_alarms=1\n";
+    if (!c.alarms.empty()) {
+        f << std::format("num_alarms={}\n", (int)c.alarms.size());
+        for (int i = 0; i < (int)c.alarms.size(); ++i) {
+            const auto& a = c.alarms[i];
+            if (!a.name.empty()) f << std::format("alarm{}_name={}\n", i, a.name);
+            f << std::format("alarm{}_schedule={}\nalarm{}_hour={}\nalarm{}_min={}\n",
+                             i, (int)a.schedule, i, a.hour, i, a.minute);
+            if (a.schedule == AlarmSchedule::Days)
+                f << std::format("alarm{}_days={}\n", i, a.days_mask);
+            else
+                f << std::format("alarm{}_year={}\nalarm{}_month={}\nalarm{}_day={}\n",
+                                 i, a.date_year, i, a.date_month, i, a.date_day);
+            if (!a.enabled) f << std::format("alarm{}_enabled=0\n", i);
+        }
+    }
     Config defaults;
     if (c.pomodoro_work_secs != defaults.pomodoro_work_secs ||
         c.pomodoro_short_secs != defaults.pomodoro_short_secs ||
@@ -118,6 +134,15 @@ inline bool config_read(Config& c, std::istream& f) {
                 c.timer_labels[i] = std::string(rest.substr(0, Config::MAX_LABEL_LEN));
                 handled_str = true;
             }
+        } else if (key.starts_with("alarm") && key.ends_with("_name")) {
+            auto num = key.substr(5, key.size() - 10);
+            int i;
+            auto [ptr, ec] = std::from_chars(num.data(), num.data() + num.size(), i);
+            if (ec == std::errc{} && ptr == num.data() + num.size() && i >= 0 && i < ALARM_MAX_COUNT) {
+                if (i >= (int)c.alarms.size()) c.alarms.resize(i + 1);
+                c.alarms[i].name = std::string(rest.substr(0, 40));
+                handled_str = true;
+            }
         }
         if (handled_str) continue;
         long long val;
@@ -125,7 +150,37 @@ inline bool config_read(Config& c, std::istream& f) {
         auto clamp_int = [](long long v, int lo, int hi) -> int {
             return (int)std::clamp(v, (long long)lo, (long long)hi);
         };
-        if (key == "clock_view") {
+        if (key == "show_alarms")
+            c.show_alarms = val != 0;
+        else if (key == "num_alarms") {
+            int n = clamp_int(val, 0, ALARM_MAX_COUNT);
+            if (n > (int)c.alarms.size()) c.alarms.resize(n);
+        } else if (key.starts_with("alarm") && key.size() > 5) {
+            auto rest2 = key.substr(5);
+            int i = -1;
+            auto [ptr, ec] = std::from_chars(rest2.data(), rest2.data() + rest2.size(), i);
+            if (ec == std::errc{} && i >= 0 && i < ALARM_MAX_COUNT) {
+                if (i >= (int)c.alarms.size()) c.alarms.resize(i + 1);
+                auto& a = c.alarms[i];
+                std::string_view field{ptr, rest2.data() + rest2.size()};
+                if (field == "_schedule")
+                    a.schedule = (AlarmSchedule)clamp_int(val, 0, 1);
+                else if (field == "_days")
+                    a.days_mask = clamp_int(val, 0, ALARM_ALL_DAYS);
+                else if (field == "_hour")
+                    a.hour = clamp_int(val, 0, 23);
+                else if (field == "_min")
+                    a.minute = clamp_int(val, 0, 59);
+                else if (field == "_year")
+                    a.date_year = clamp_int(val, 2000, 9999);
+                else if (field == "_month")
+                    a.date_month = clamp_int(val, 1, 12);
+                else if (field == "_day")
+                    a.date_day = clamp_int(val, 1, 31);
+                else if (field == "_enabled")
+                    a.enabled = val != 0;
+            }
+        } else if (key == "clock_view") {
             c.clock_view = (ClockView)clamp_int(val, 0, CLOCK_VIEW_COUNT - 1);
         } else if (key == "num_custom_presets") {
             c.num_custom_presets = clamp_int(val, 0, Config::MAX_CUSTOM_PRESETS);

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -8,7 +8,9 @@ inline LayoutState layout_state(const WndState& s) {
         .show_clk = s.app.show_clk,
         .show_sw = s.app.show_sw,
         .show_tmr = s.app.show_tmr,
+        .show_alarms = s.app.show_alarms,
         .timer_count = (int)s.app.timers.size(),
+        .alarm_count = (int)s.app.alarms.size(),
         .clock_view = s.app.clock_view,
     };
 }

--- a/src/input_core.hpp
+++ b/src/input_core.hpp
@@ -66,6 +66,7 @@ inline void handle(HWND hwnd, int act, WndState& s) {
         }
     }
     if (r.open_alarm_dialog) {
+        if (s.app.alarms.size() >= (size_t)ALARM_MAX_COUNT) return;
         Alarm new_alarm;
         if (alarm_dlg::show_add_alarm_dialog(hwnd, new_alarm,
                 (HFONT)s.fontSm.h, s.active_theme, s.layout.dpi)) {

--- a/src/input_core.hpp
+++ b/src/input_core.hpp
@@ -69,10 +69,7 @@ inline void handle(HWND hwnd, int act, WndState& s) {
         Alarm new_alarm;
         if (alarm_dlg::show_add_alarm_dialog(hwnd, new_alarm,
                 (HFONT)s.fontSm.h, s.active_theme, s.layout.dpi)) {
-            s.app.alarms.reserve(s.app.alarms.size() + 1);
-            s.app.alarm_notified.reserve(s.app.alarm_notified.size() + 1);
             s.app.alarms.push_back(new_alarm);
-            s.app.alarm_notified.push_back(false);
             resize_window(hwnd, s);
             save_config(hwnd, s);
         }

--- a/src/input_core.hpp
+++ b/src/input_core.hpp
@@ -65,11 +65,12 @@ inline void handle(HWND hwnd, int act, WndState& s) {
             save_config(hwnd, s);
         }
     }
-    if (r.open_alarm_dialog) {
-        if (s.app.alarms.size() >= (size_t)ALARM_MAX_COUNT) return;
+    if (r.open_alarm_dialog && s.app.alarms.size() < (size_t)ALARM_MAX_COUNT) {
         Alarm new_alarm;
         if (alarm_dlg::show_add_alarm_dialog(hwnd, new_alarm,
                 (HFONT)s.fontSm.h, s.active_theme, s.layout.dpi)) {
+            s.app.alarms.reserve(s.app.alarms.size() + 1);
+            s.app.alarm_notified.reserve(s.app.alarm_notified.size() + 1);
             s.app.alarms.push_back(new_alarm);
             s.app.alarm_notified.push_back(false);
             resize_window(hwnd, s);

--- a/src/input_core.hpp
+++ b/src/input_core.hpp
@@ -3,6 +3,7 @@
 #include <shellapi.h>
 #include <chrono>
 #include "actions.hpp"
+#include "alarm_dialog.hpp"
 #include "config_io.hpp"
 #include "geometry.hpp"
 #include "polling.hpp"
@@ -61,6 +62,16 @@ inline void handle(HWND hwnd, int act, WndState& s) {
         if (ui::show_settings_dialog(hwnd, s.app, (ui::FontHandle)s.fontSm.h, s.active_theme, s.layout.dpi)) {
             if (s.app.theme_mode != old_theme) apply_theme(hwnd, s);
             if (s.app.clock_view != old_clock) resize_window(hwnd, s);
+            save_config(hwnd, s);
+        }
+    }
+    if (r.open_alarm_dialog) {
+        Alarm new_alarm;
+        if (alarm_dlg::show_add_alarm_dialog(hwnd, new_alarm,
+                (HFONT)s.fontSm.h, s.active_theme, s.layout.dpi)) {
+            s.app.alarms.push_back(new_alarm);
+            s.app.alarm_notified.push_back(false);
+            resize_window(hwnd, s);
             save_config(hwnd, s);
         }
     }

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -15,8 +15,11 @@ struct Layout {
     static constexpr int BASE_W_CLK  = 48;
     static constexpr int BASE_W_SW   = 76;
     static constexpr int BASE_W_TMR  = 54;
+    static constexpr int BASE_W_ALM  = 56;
     static constexpr int BASE_W_SET  = 32;
     static constexpr int BASE_BAR_GAP = 6;
+    static constexpr int BASE_ALARM_HEADER_H = 42;
+    static constexpr int BASE_ALARM_ROW_H    = 32;
 
     int bar_h   = BASE_BAR_H;
     int clk_h   = BASE_CLK_H;
@@ -29,12 +32,15 @@ struct Layout {
     int w_clk   = BASE_W_CLK;
     int w_sw    = BASE_W_SW;
     int w_tmr   = BASE_W_TMR;
+    int w_alm   = BASE_W_ALM;
     int w_set   = BASE_W_SET;
     int bar_gap = BASE_BAR_GAP;
+    int alarm_header_h = BASE_ALARM_HEADER_H;
+    int alarm_row_h    = BASE_ALARM_ROW_H;
 
     int dpi = STANDARD_DPI;
 
-    int bar_min_client_w() const { return w_pin + w_clk + w_sw + w_tmr + w_set + 4 * bar_gap + 2 * dpi_scale(8); }
+    int bar_min_client_w() const { return w_pin + w_clk + w_sw + w_tmr + w_alm + w_set + 5 * bar_gap + 2 * dpi_scale(8); }
 
     int dpi_scale(int value) const {
         CHRONOS_ASSERT(dpi > 0);
@@ -54,8 +60,11 @@ struct Layout {
         w_clk   = dpi_scale(BASE_W_CLK);
         w_sw    = dpi_scale(BASE_W_SW);
         w_tmr   = dpi_scale(BASE_W_TMR);
+        w_alm   = dpi_scale(BASE_W_ALM);
         w_set   = dpi_scale(BASE_W_SET);
         bar_gap = dpi_scale(BASE_BAR_GAP);
+        alarm_header_h = dpi_scale(BASE_ALARM_HEADER_H);
+        alarm_row_h    = dpi_scale(BASE_ALARM_ROW_H);
     }
 };
 
@@ -63,7 +72,9 @@ struct LayoutState {
     bool show_clk = true;
     bool show_sw = true;
     bool show_tmr = true;
+    bool show_alarms = false;
     int timer_count = 1;
+    int alarm_count = 0;
     ClockView clock_view = ClockView::H24_HMS;
 };
 
@@ -100,6 +111,7 @@ inline int client_height_for(const Layout& layout, const LayoutState& state) {
     if (state.show_clk) h += effective_clk_h(layout, state.clock_view);
     if (state.show_sw) h += layout.sw_h;
     if (state.show_tmr) h += state.timer_count * layout.tmr_h;
+    if (state.show_alarms) h += layout.alarm_header_h + state.alarm_count * layout.alarm_row_h;
     return h;
 }
 

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -111,7 +111,7 @@ inline int client_height_for(const Layout& layout, const LayoutState& state) {
     if (state.show_clk) h += effective_clk_h(layout, state.clock_view);
     if (state.show_sw) h += layout.sw_h;
     if (state.show_tmr) h += state.timer_count * layout.tmr_h;
-    if (state.show_alarms) h += layout.alarm_header_h + state.alarm_count * layout.alarm_row_h;
+    if (state.show_alarms) h += layout.alarm_header_h + (state.alarm_count > 0 ? state.alarm_count : 1) * layout.alarm_row_h;
     return h;
 }
 

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include "assert.hpp"
 #include "actions.hpp"
+#include "encoding.hpp"
 #include "app.hpp"
 #include "formatting.hpp"
 #include "layout.hpp"
@@ -142,15 +143,13 @@ inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
     int del_w = layout.dpi_scale(36);
     int tog_w = layout.dpi_scale(50);
 
+    HBRUSH stripe = CreateSolidBrush(th.bar);
     for (int i = 0; i < (int)ctx.app.alarms.size(); ++i) {
         const auto& a = ctx.app.alarms[i];
 
         RECT row_bg{0, row_y, cw, row_y + layout.alarm_row_h};
-        if (i % 2 == 1) {
-            HBRUSH stripe = CreateSolidBrush(th.bar);
+        if (i % 2 == 1)
             FillRect(hdc, &row_bg, stripe);
-            DeleteObject(stripe);
-        }
 
         // Build schedule string
         std::wstring sched;
@@ -167,7 +166,7 @@ inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
         }
         std::wstring label;
         {
-            std::wstring name_w(a.name.begin(), a.name.end());
+            std::wstring name_w = utf8_to_wide(a.name);
             if (!name_w.empty()) label = name_w + L"  ";
         }
         label += std::format(L"{:02}:{:02}  {}", a.hour, a.minute, sched);
@@ -191,12 +190,13 @@ inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
 
         row_y += layout.alarm_row_h;
     }
+    DeleteObject(stripe);
 
     if (ctx.app.alarms.empty()) {
         SetTextColor(hdc, th.dim);
-        RECT er{pad, row_y, cw - pad, row_y + layout.dpi_scale(28)};
+        RECT er{pad, row_y, cw - pad, row_y + layout.alarm_row_h};
         DrawTextW(hdc, L"No alarms set", -1, &er, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
-        row_y += layout.dpi_scale(28);
+        row_y += layout.alarm_row_h;
     }
 
     return row_y;

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -24,7 +24,7 @@ inline int paint_bar(HDC hdc, int cw, PaintCtx& ctx) {
 
     SelectObject(hdc, ctx.res.fontSm);
     int by = (layout.bar_h - layout.btn_h) / 2;
-    int bx = (cw - (layout.w_pin + layout.w_clk + layout.w_sw + layout.w_tmr + layout.w_set + 4 * layout.bar_gap)) / 2;
+    int bx = (cw - (layout.w_pin + layout.w_clk + layout.w_sw + layout.w_tmr + layout.w_alm + layout.w_set + 5 * layout.bar_gap)) / 2;
     btn(hdc, {bx, by, bx + layout.w_pin, by + layout.btn_h}, ctx.app.topmost, L"Pin", A_TOPMOST, ctx);
     bx += layout.w_pin + layout.bar_gap;
     btn(hdc, {bx, by, bx + layout.w_clk, by + layout.btn_h}, ctx.app.show_clk, L"Clock", A_SHOW_CLK, ctx);
@@ -33,6 +33,8 @@ inline int paint_bar(HDC hdc, int cw, PaintCtx& ctx) {
     bx += layout.w_sw + layout.bar_gap;
     btn(hdc, {bx, by, bx + layout.w_tmr, by + layout.btn_h}, ctx.app.show_tmr, L"Timers", A_SHOW_TMR, ctx);
     bx += layout.w_tmr + layout.bar_gap;
+    btn(hdc, {bx, by, bx + layout.w_alm, by + layout.btn_h}, ctx.app.show_alarms, L"Alarms", A_SHOW_ALARMS, ctx);
+    bx += layout.w_alm + layout.bar_gap;
     btn(hdc, {bx, by, bx + layout.w_set, by + layout.btn_h}, false, L"\u2699", A_SETTINGS, ctx);
     return layout.bar_h;
 }
@@ -119,6 +121,87 @@ inline int paint_stopwatch(HDC hdc, int cw, int y, PaintCtx& ctx, std::chrono::s
     return y + layout.sw_h;
 }
 
+inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
+    auto& layout = ctx.layout;
+    auto& th = ctx.theme;
+    divider(hdc, y, cw, ctx);
+
+    int pad = layout.dpi_scale(10);
+    int bw  = layout.dpi_scale(56);
+    int bh  = layout.dpi_scale(24);
+    int by0 = y + (layout.alarm_header_h - bh) / 2;
+
+    SelectObject(hdc, ctx.res.fontSm);
+    SetTextColor(hdc, th.text);
+    RECT title_r{pad, y, cw - bw - 2 * pad, y + layout.alarm_header_h};
+    DrawTextW(hdc, L"Alarms", -1, &title_r, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+
+    btn(hdc, {cw - bw - pad, by0, cw - pad, by0 + bh}, false, L"+ Add", A_ALARM_ADD, ctx);
+
+    int row_y = y + layout.alarm_header_h;
+    int del_w = layout.dpi_scale(36);
+    int tog_w = layout.dpi_scale(50);
+
+    for (int i = 0; i < (int)ctx.app.alarms.size(); ++i) {
+        const auto& a = ctx.app.alarms[i];
+
+        RECT row_bg{0, row_y, cw, row_y + layout.alarm_row_h};
+        if (i % 2 == 1) {
+            HBRUSH stripe = CreateSolidBrush(th.bar);
+            FillRect(hdc, &row_bg, stripe);
+            DeleteObject(stripe);
+        }
+
+        // Build schedule string
+        std::wstring sched;
+        if (a.schedule == AlarmSchedule::Days) {
+            const wchar_t* day_names[] = {L"Mo", L"Tu", L"We", L"Th", L"Fr", L"Sa", L"Su"};
+            for (int d = 0; d < 7; ++d)
+                if (a.days_mask & (1 << d)) {
+                    if (!sched.empty()) sched += L' ';
+                    sched += day_names[d];
+                }
+            if (sched.empty()) sched = L"(no days)";
+        } else {
+            sched = std::format(L"{:04}-{:02}-{:02}", a.date_year, a.date_month, a.date_day);
+        }
+        std::wstring label;
+        {
+            std::wstring name_w(a.name.begin(), a.name.end());
+            if (!name_w.empty()) label = name_w + L"  ";
+        }
+        label += std::format(L"{:02}:{:02}  {}", a.hour, a.minute, sched);
+
+        int text_x = pad;
+        int row_mid = row_y + layout.alarm_row_h / 2;
+        int text_h  = layout.dpi_scale(18);
+        int buttons_right = cw - pad;
+        int del_x  = buttons_right - del_w;
+        int tog_x  = del_x - layout.dpi_scale(6) - tog_w;
+
+        RECT lr{text_x, row_mid - text_h / 2, tog_x - layout.dpi_scale(6), row_mid + text_h / 2};
+        SetTextColor(hdc, a.enabled ? th.text : th.dim);
+        DrawTextW(hdc, label.c_str(), -1, &lr, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS);
+
+        int btn_top = row_mid - bh / 2;
+        btn(hdc, {tog_x, btn_top, tog_x + tog_w, btn_top + bh},
+            a.enabled, a.enabled ? L"On" : L"Off", A_ALARM_TOGGLE + i, ctx);
+        btn(hdc, {del_x, btn_top, del_x + del_w, btn_top + bh},
+            false, L"Del", A_ALARM_DEL + i, ctx);
+
+        row_y += layout.alarm_row_h;
+    }
+
+    if (ctx.app.alarms.empty()) {
+        SetTextColor(hdc, th.dim);
+        RECT er{pad, row_y, cw - pad, row_y + layout.dpi_scale(28)};
+        DrawTextW(hdc, L"No alarms set", -1, &er, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        row_y += layout.dpi_scale(28);
+    }
+
+    return row_y;
+}
+
 inline void paint_help(HDC hdc, int cw, int y_bottom, PaintCtx& ctx) {
     auto& layout = ctx.layout;
     RECT cr{0, layout.bar_h, cw, y_bottom > layout.bar_h ? y_bottom : layout.bar_h + layout.dpi_scale(200)};
@@ -180,5 +263,6 @@ inline void paint_all(HDC hdc, int cw, int ch, PaintCtx& ctx) {
     if (ctx.app.show_clk) y = paint_clock(hdc, cw, y, ctx);
     if (ctx.app.show_sw) y = paint_stopwatch(hdc, cw, y, ctx, now);
     if (ctx.app.show_tmr) y = paint_timers(hdc, cw, y, ctx, now);
+    if (ctx.app.show_alarms) y = paint_alarms(hdc, cw, y, ctx);
     if (ctx.app.show_help) paint_help(hdc, cw, y, ctx);
 }

--- a/src/polling.hpp
+++ b/src/polling.hpp
@@ -67,10 +67,7 @@ inline void check_alarms(HWND hwnd, WndState& s) {
     // Reset notified flags at the start of each new minute
     if (current_minute != app.alarm_notified_minute) {
         app.alarm_notified_minute = current_minute;
-        app.alarm_notified.assign(app.alarms.size(), false);
-    } else {
-        // Ensure size matches (alarms may have been added/removed)
-        app.alarm_notified.resize(app.alarms.size(), false);
+        for (auto& a : app.alarms) a.notified = false;
     }
 
     // SYSTEMTIME wDayOfWeek: 0=Sunday, 1=Monday, ..., 6=Saturday
@@ -78,10 +75,9 @@ inline void check_alarms(HWND hwnd, WndState& s) {
     int dow_sys = st.wDayOfWeek; // 0=Sun
     int dow_bit = (dow_sys == 0) ? 6 : (dow_sys - 1); // Mon=0 ... Sun=6
 
-    for (int i = 0; i < (int)app.alarms.size(); ++i) {
-        const auto& a = app.alarms[i];
+    for (auto& a : app.alarms) {
         if (!a.enabled) continue;
-        if (app.alarm_notified[i]) continue;
+        if (a.notified) continue;
         if (a.hour != st.wHour || a.minute != st.wMinute) continue;
 
         bool matches = false;
@@ -94,7 +90,7 @@ inline void check_alarms(HWND hwnd, WndState& s) {
         }
         if (!matches) continue;
 
-        app.alarm_notified[i] = true;
+        a.notified = true;
         MessageBeep(MB_ICONASTERISK);
         FLASHWINFO fi{sizeof(fi), hwnd, FLASHW_ALL | FLASHW_TIMERNOFG, 3, 0};
         FlashWindowEx(&fi);

--- a/src/polling.hpp
+++ b/src/polling.hpp
@@ -100,7 +100,7 @@ inline void check_alarms(HWND hwnd, WndState& s) {
         FlashWindowEx(&fi);
 
         if (s.tray_active) {
-            std::wstring name_w(a.name.begin(), a.name.end());
+            std::wstring name_w = utf8_to_wide(a.name);
             const wchar_t* title = L"Alarm";
             tray_notify(hwnd, title, name_w.empty() ? title : name_w.c_str());
         }

--- a/src/polling.hpp
+++ b/src/polling.hpp
@@ -57,6 +57,56 @@ inline void update_title(HWND hwnd, WndState& s) {
     if (s.tray_active) tray_update_tip(hwnd, title.c_str());
 }
 
+inline void check_alarms(HWND hwnd, WndState& s) {
+    auto& app = s.app;
+    if (app.alarms.empty()) return;
+
+    SYSTEMTIME st; GetLocalTime(&st);
+    int current_minute = st.wHour * 60 + st.wMinute;
+
+    // Reset notified flags at the start of each new minute
+    if (current_minute != app.alarm_notified_minute) {
+        app.alarm_notified_minute = current_minute;
+        app.alarm_notified.assign(app.alarms.size(), false);
+    } else {
+        // Ensure size matches (alarms may have been added/removed)
+        app.alarm_notified.resize(app.alarms.size(), false);
+    }
+
+    // SYSTEMTIME wDayOfWeek: 0=Sunday, 1=Monday, ..., 6=Saturday
+    // Our bitmask: bit 0=Monday ... bit 6=Sunday
+    int dow_sys = st.wDayOfWeek; // 0=Sun
+    int dow_bit = (dow_sys == 0) ? 6 : (dow_sys - 1); // Mon=0 ... Sun=6
+
+    for (int i = 0; i < (int)app.alarms.size(); ++i) {
+        const auto& a = app.alarms[i];
+        if (!a.enabled) continue;
+        if (app.alarm_notified[i]) continue;
+        if (a.hour != st.wHour || a.minute != st.wMinute) continue;
+
+        bool matches = false;
+        if (a.schedule == AlarmSchedule::Days) {
+            matches = (a.days_mask & (1 << dow_bit)) != 0;
+        } else {
+            matches = (a.date_year  == st.wYear  &&
+                       a.date_month == st.wMonth &&
+                       a.date_day   == st.wDay);
+        }
+        if (!matches) continue;
+
+        app.alarm_notified[i] = true;
+        MessageBeep(MB_ICONASTERISK);
+        FLASHWINFO fi{sizeof(fi), hwnd, FLASHW_ALL | FLASHW_TIMERNOFG, 3, 0};
+        FlashWindowEx(&fi);
+
+        if (s.tray_active) {
+            std::wstring name_w(a.name.begin(), a.name.end());
+            const wchar_t* title = L"Alarm";
+            tray_notify(hwnd, title, name_w.empty() ? title : name_w.c_str());
+        }
+    }
+}
+
 inline void handle_wm_timer(HWND hwnd, WndState& s) {
     using namespace std::chrono;
     auto now = steady_clock::now();
@@ -86,6 +136,7 @@ inline void handle_wm_timer(HWND hwnd, WndState& s) {
             }
         }
     }
+    check_alarms(hwnd, s);
     update_title(hwnd, s);
     InvalidateRect(hwnd, nullptr, FALSE);
     sync_timer(hwnd, s);

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -53,8 +53,8 @@ TEST_CASE("Layout update_for_dpi: 192 DPI doubles values", "[layout]") {
 TEST_CASE("Layout bar_min_client_w: correct at 96 DPI", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    // w_pin(44) + w_clk(48) + w_sw(76) + w_tmr(54) + w_set(32) + 4*bar_gap(6) + 2*dpi_scale(8)
-    int expected = 44 + 48 + 76 + 54 + 32 + 4 * 6 + 2 * 8;
+    // w_pin(44) + w_clk(48) + w_sw(76) + w_tmr(54) + w_alm(56) + w_set(32) + 5*bar_gap(6) + 2*dpi_scale(8)
+    int expected = 44 + 48 + 76 + 54 + 56 + 32 + 5 * 6 + 2 * 8;
     REQUIRE(l.bar_min_client_w() == expected);
 }
 
@@ -63,7 +63,7 @@ TEST_CASE("Layout bar_min_client_w: correct at 96 DPI", "[layout]") {
 TEST_CASE("client_height_for: all sections visible", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{true, true, true, 2};
+    LayoutState s{true, true, true, false, 2};
     // bar_h + clk_h + sw_h + 2*tmr_h
     REQUIRE(client_height_for(l, s) == 36 + 62 + 116 + 2 * 114);
 }
@@ -71,21 +71,21 @@ TEST_CASE("client_height_for: all sections visible", "[layout]") {
 TEST_CASE("client_height_for: none visible", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{false, false, false, 1};
+    LayoutState s{false, false, false, false, 1};
     REQUIRE(client_height_for(l, s) == 36); // just bar
 }
 
 TEST_CASE("client_height_for: only clock", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{true, false, false, 1};
+    LayoutState s{true, false, false, false, 1};
     REQUIRE(client_height_for(l, s) == 36 + 62);
 }
 
 TEST_CASE("client_height_for: timers with 3 slots", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{false, false, true, 3};
+    LayoutState s{false, false, true, false, 3};
     REQUIRE(client_height_for(l, s) == 36 + 3 * 114);
 }
 
@@ -94,7 +94,7 @@ TEST_CASE("client_height_for: timers with 3 slots", "[layout]") {
 TEST_CASE("timer_index_at_y: click in timer region", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{true, true, true, 2};
+    LayoutState s{true, true, true, false, 2};
     int top = l.bar_h + l.clk_h + l.sw_h;
     REQUIRE(timer_index_at_y(l, s, top + 1) == 0);
     REQUIRE(timer_index_at_y(l, s, top + l.tmr_h + 1) == 1);
@@ -103,21 +103,21 @@ TEST_CASE("timer_index_at_y: click in timer region", "[layout]") {
 TEST_CASE("timer_index_at_y: click above timer region", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{true, true, true, 1};
+    LayoutState s{true, true, true, false, 1};
     REQUIRE(timer_index_at_y(l, s, l.bar_h) == -1);
 }
 
 TEST_CASE("timer_index_at_y: timers hidden", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{false, false, false, 0};
+    LayoutState s{false, false, false, false, 0};
     REQUIRE(timer_index_at_y(l, s, 50) == -1);
 }
 
 TEST_CASE("timer_index_at_y: click below all timers", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{false, false, true, 1};
+    LayoutState s{false, false, true, false, 1};
     int bottom = l.bar_h + l.tmr_h;
     REQUIRE(timer_index_at_y(l, s, bottom + 10) == -1);
 }
@@ -125,8 +125,8 @@ TEST_CASE("timer_index_at_y: click below all timers", "[layout]") {
 TEST_CASE("client_height_for: analog clock uses taller height", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState digital{true, false, false, 1, ClockView::H24_HMS};
-    LayoutState analog{true, false, false, 1, ClockView::Analog};
+    LayoutState digital{true, false, false, false, 1, 0, ClockView::H24_HMS};
+    LayoutState analog{true, false, false, false, 1, 0, ClockView::Analog};
     int h_digital = client_height_for(l, digital);
     int h_analog = client_height_for(l, analog);
     REQUIRE(h_digital == 36 + 62);
@@ -147,7 +147,7 @@ TEST_CASE("effective_clk_h returns correct height per view", "[layout]") {
 TEST_CASE("timer_index_at_y accounts for analog clock height", "[layout]") {
     Layout l;
     l.update_for_dpi(96);
-    LayoutState s{true, false, true, 1, ClockView::Analog};
+    LayoutState s{true, false, true, false, 1, 0, ClockView::Analog};
     int top = l.bar_h + l.analog_clk_h;
     REQUIRE(timer_index_at_y(l, s, top + 1) == 0);
     REQUIRE(timer_index_at_y(l, s, top - 1) == -1);

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -152,3 +152,18 @@ TEST_CASE("timer_index_at_y accounts for analog clock height", "[layout]") {
     REQUIRE(timer_index_at_y(l, s, top + 1) == 0);
     REQUIRE(timer_index_at_y(l, s, top - 1) == -1);
 }
+
+TEST_CASE("client_height_for: alarms visible with zero count reserves one row", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    LayoutState s{false, false, false, true, 0, 0};
+    // bar_h + alarm_header_h + 1*alarm_row_h (empty-state row)
+    REQUIRE(client_height_for(l, s) == 36 + 42 + 32);
+}
+
+TEST_CASE("client_height_for: alarms visible with two alarms", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    LayoutState s{false, false, false, true, 0, 2};
+    REQUIRE(client_height_for(l, s) == 36 + 42 + 2 * 32);
+}


### PR DESCRIPTION
Closes #330

## Summary

- **Alarm data model** (`alarm.hpp`): `Alarm` struct with day-of-week schedule (Mon–Sun bitmask) or specific-date schedule, plus name, hour, minute, enabled flag
- **Alarms section** in main window: new "Alarms" toggle button in top bar; panel shows all alarms with On/Off and Del per row, plus "+ Add" button; empty state shown when no alarms
- **Add Alarm dialog** (`alarm_dialog.hpp`): Days/Date schedule toggle; interactive day buttons (Mon–Sun) for days schedule; year/month/day fields for date schedule; HH:MM time input; name field
- **Alarm firing** (`polling.hpp`): checked each timer tick; fires `MessageBeep` + `FlashWindowEx` + tray balloon when hour+minute match and day/date condition met; debounced to once per minute per alarm
- **Persistence**: alarms and `show_alarms` serialised to `config.ini` via `config_serial.hpp`; restored on startup via `config_io.hpp`

## Test plan

- [ ] Build succeeds (`cmake --build build`)
- [ ] "Alarms" button appears in top bar; clicking toggles the alarms panel
- [ ] "+ Add" opens dialog; Days mode shows Mon–Sun toggles; Date mode shows year/month/day fields; name and time fields work; OK saves, Cancel discards
- [ ] Added alarm appears in list with correct schedule string and time
- [ ] On/Off toggle enables/disables an alarm (dim label when off)
- [ ] Del removes alarm from list; window resizes accordingly
- [ ] Alarm fires at the correct minute (MessageBeep + taskbar flash)
- [ ] Alarms persist across app restart


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTwpP18ZRx5w34VGGeADdW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full alarm support: named alarms, weekday-mask or specific-date schedules, enable/disable, add dialog with validation and max-alarm limit.

* **UI**
  * "Alarms" button in the bar and an Alarms panel with “+ Add”, per-alarm On/Off toggles, Delete buttons, and empty-state message; layout/spacing adjusted.

* **Persistence**
  * Alarms and panel visibility are saved and restored.

* **Notifications**
  * Alarms trigger audio, window flash, and optional tray messages; notifications reset per-minute.

* **Tests**
  * Layout tests updated for alarms column, reserved rows, and spacing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/331)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->