### PR TITLE
feat: right-click to decrement/reset in analog clock settings

### DIFF
--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -666,6 +666,39 @@ static INT_PTR on_command(HWND dlg, WPARAM wp) {
     return FALSE;
 }
 
+static INT_PTR on_right_button_down(HWND dlg, LPARAM lp) {
+    auto* p = dialog_params(dlg);
+    if (!p) return FALSE;
+    if (p->active_tab != TAB_CLOCK || p->clock_view != ClockView::Analog) return FALSE;
+
+    POINT spt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp) + p->scroll_y};
+
+    for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
+        if (PtInRect(&p->rects.analog_colors[i], spt)) {
+            int* field = analog_color_field(p->analog_style, i);
+            if (field) {
+                *field = -1;
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
+        }
+    }
+    for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
+        if (PtInRect(&p->rects.analog_values[i], spt)) {
+            int* field = analog_value_field(p->analog_style, i);
+            if (field) {
+                int min_v, max_v, step;
+                analog_value_range(i, min_v, max_v, step);
+                *field -= step;
+                if (*field < min_v) *field = max_v;
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
+        }
+    }
+    return FALSE;
+}
+
 static INT_PTR on_key_down(HWND dlg, WPARAM wp) {
     if (wp == VK_ESCAPE) {
         EndDialog(dlg, IDCANCEL);
@@ -692,6 +725,7 @@ static INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_NCHITTEST:        return on_nc_hit_test(dlg, lp);
     case WM_DRAWITEM:         return on_draw_item(dlg, lp);
     case WM_LBUTTONDOWN:      return on_left_button_down(dlg, lp);
+    case WM_RBUTTONDOWN:      return on_right_button_down(dlg, lp);
     case WM_VSCROLL:          return on_scroll(dlg, wp);
     case WM_MOUSEWHEEL:       return on_mouse_wheel(dlg, wp);
     case WM_COMMAND:          return on_command(dlg, wp);


### PR DESCRIPTION
Closes #302

## Summary

- Right-click on a **value button** (length, thickness, opacity, radius, etc.) decrements by one step, wrapping from min back to max — the mirror image of left-click which increments and wraps from max to min.
- Right-click on a **color button** resets it to "auto" (−1), removing any custom colour without having to cycle through the full 9-colour palette back to auto.

## Why

Before this change, the only way to go backwards on a value was to click through every step until it wrapped around (e.g., going from 100% opacity down to 10% required 18 left-clicks). Similarly, resetting a colour to auto meant cycling through all 8 palette entries. Right-click makes the controls bidirectional and gives a fast reset path for colours.

## Test plan

- [ ] Open Settings → Clock → Analog
- [ ] Left-click a value button repeatedly; confirm it increments and wraps to min at max
- [ ] Right-click the same button; confirm it decrements and wraps to max at min
- [ ] Left-click a colour button to set a custom colour; right-click it; confirm it resets to auto (colour swatch returns to the theme dim colour)
- [ ] Confirm live preview updates immediately on both left- and right-click
- [ ] Confirm right-click on non-analog tabs / non-clock tabs does nothing

https://claude.ai/code/session_01JgRBBzDJ3V2mKhYUcTH6x7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgRBBzDJ3V2mKhYUcTH6x7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click support for analog clock customization in the Settings dialog. Right-clicking color controls resets them to their default non-custom state. Right-clicking numeric value controls decrements them by the appropriate step amount, with automatic wraparound back to the maximum value when dropping below the minimum threshold.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/340)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->