### PR TITLE
fix: appearance buttons always draw as unchecked (#346)

### DIFF
--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -470,7 +470,7 @@ static INT_PTR on_draw_item(HWND dlg, LPARAM lp) {
     }
 
     bool is_radio = (di->CtlID == IDC_THEME_AUTO || di->CtlID == IDC_THEME_LIGHT || di->CtlID == IDC_THEME_DARK);
-    bool checked = (di->itemState & ODS_CHECKED) != 0;
+    bool checked = SendMessage(di->hwndItem, BM_GETCHECK, 0, 0) == BST_CHECKED;
     wchar_t ctrl_label[64] = {};
     GetWindowTextW(di->hwndItem, ctrl_label, 63);
     p->style.draw_check_radio(di->hDC, di->rcItem, ctrl_label, checked, is_radio);


### PR DESCRIPTION
## Summary
- Fixes issue #346: appearance theme/sound buttons appeared unresponsive because they always rendered as unchecked
- Root cause: `on_draw_item` was reading checked state from `ODS_CHECKED` (which is unreliable for owner-drawn buttons) — switched to `BM_GETCHECK` which returns the actual button state

## Test plan
- [ ] Open settings → Appearance tab
- [ ] Click each theme radio button (Auto/Light/Dark) — selected button should visually check
- [ ] Click Sound checkbox — should toggle visually

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect display state of theme selection controls to accurately reflect their current state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->