### PR TITLE
fix: clock config layout — combo overlap and Live preview gap (#345)

### DIFF
--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -377,7 +377,7 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
             }
 
             // Fixed preview drawn on top — no sdy offset
-            RECT prev_lbl = map_dlu(dlg, 68, 48, 80, 8);
+            RECT prev_lbl = map_dlu(dlg, 68, 64, 80, 8);
             s.draw_label(hdc, prev_lbl, L"Live preview");
             draw_analog_clock(hdc, preview, p->analog_style, *s.theme, s.dpi, 10, 10, 30);
         }

--- a/src/ui_windows_settings_dialog_scroll.hpp
+++ b/src/ui_windows_settings_dialog_scroll.hpp
@@ -61,9 +61,8 @@ static void position_scrollable_controls(HWND dlg, const Params& p) {
     SetWindowPos(combo, nullptr,
                  p.clock_combo_rc.left,
                  p.clock_combo_rc.top - p.scroll_y,
-                 p.clock_combo_rc.right - p.clock_combo_rc.left,
-                 p.clock_combo_rc.bottom - p.clock_combo_rc.top,
-                 SWP_NOZORDER | SWP_NOACTIVATE);
+                 0, 0,
+                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
 }
 
 static int rect_bottom_after_scroll(const RECT& r, const Params& p) {

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -27,8 +27,8 @@ static HitRects compute_rects(HWND dlg) {
     h.sidebar[3] = map_dlu(dlg, 3, 72, 56, 14);
 
     // Analog settings sit below the format dropdown (which is at y=40, h=12).
-    // Preview is fixed (sticky) at y=58; right column starts at x=158.
-    h.analog_preview = map_dlu(dlg, 68, 58, 80, 80);
+    // "Live preview" label at y=64 (h=8), preview fixed (sticky) at y=76; right column starts at x=158.
+    h.analog_preview = map_dlu(dlg, 68, 76, 80, 80);
     h.analog_min_ticks = map_dlu(dlg, 158,  64, 122, 12);
     h.analog_labels[0] = map_dlu(dlg, 158,  92,  40, 12);
     h.analog_labels[1] = map_dlu(dlg, 202,  92,  40, 12);


### PR DESCRIPTION
## Summary
- **Combo HWND overflow**: `position_scrollable_controls` was calling `SetWindowPos` with the full `clock_combo_rc` height (80 DLU — the dropdown-list reserve from the dialog template). This resized the combo HWND on every scroll update, causing it to cover the analog clock preview area. Fixed by adding `SWP_NOSIZE` so only the y-position scrolls.
- **"Live preview" label gap**: The label was at DLU y=48, inside the combo's visual area (~y=40–53), giving effectively no gap. Moved to y=64 to match the vertical alignment of the Min ticks row in the right column. `analog_preview` rect shifted to y=76 to sit cleanly below the label.

## Test plan
- [ ] Open Settings → Clock tab → select Analog
- [ ] Confirm "Live preview" label appears with the same gap below the format dropdown as "Min ticks" has in the right column
- [ ] Confirm the analog clock preview is no longer obscured by the format dropdown control
- [ ] Scroll the analog settings — verify combo box moves correctly with scroll and preview stays fixed
- [ ] Switch between Analog and non-Analog clock views — verify no visual artifacts

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Adjustments**
  * Refined the vertical positioning of the analog clock preview area and related labels within the settings dialog to improve visual layout and alignment
  * Enhanced control positioning logic and interactive boundaries for clock-related elements in the settings interface for improved usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/349)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->