### PR TITLE
fix: extra space at bottom when dragged to vertical/portrait monitor (#347)

### DIFF
--- a/src/window.hpp
+++ b/src/window.hpp
@@ -67,12 +67,6 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             ShowWindow(hwnd, SW_HIDE);
             return 0;
         }
-        {
-            RECT cr;
-            GetClientRect(hwnd, &cr);
-            if (cr.bottom != client_height(*s))
-                resize_window(hwnd, *s);
-        }
         break;
     case WM_TRAYICON: {
         auto tray_restore = [&] {
@@ -115,41 +109,29 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         EndPaint(hwnd, &ps);
         return 0;
     }
-    case WM_SIZING: {
-        int want_h = client_height(*s) + nonclient_height(hwnd);
-        auto* r = (RECT*)lp;
-        if (wp == WMSZ_TOP || wp == WMSZ_TOPLEFT || wp == WMSZ_TOPRIGHT)
-            r->top = r->bottom - want_h;
-        else
-            r->bottom = r->top + want_h;
-        return TRUE;
+    case WM_WINDOWPOSCHANGING: {
+        // Enforce fixed height before any size change is applied.
+        auto* pos = (WINDOWPOS*)lp;
+        if (!(pos->flags & SWP_NOSIZE))
+            pos->cy = client_height(*s) + nonclient_height(hwnd);
+        break;
     }
     case WM_GETMINMAXINFO: {
+        // Only enforce minimum width; height is handled by WM_WINDOWPOSCHANGING.
         auto* m = (MINMAXINFO*)lp;
         DWORD ws = (DWORD)GetWindowLongW(hwnd, GWL_STYLE);
         RECT adj{0, 0, s->layout.bar_min_client_w(), 0};
         AdjustWindowRectEx(&adj, ws, FALSE, 0);
         m->ptMinTrackSize.x = adj.right - adj.left;
-        RECT adj_h{0, 0, 0, client_height(*s)};
-        AdjustWindowRectEx(&adj_h, ws, FALSE, 0);
-        m->ptMinTrackSize.y = adj_h.bottom - adj_h.top;
-        m->ptMaxTrackSize.y = m->ptMinTrackSize.y;
-        m->ptMaxSize.y = m->ptMinTrackSize.y;
-        return 0;
-    }
-    case WM_WINDOWPOSCHANGED: {
-        RECT cr;
-        GetClientRect(hwnd, &cr);
-        if (cr.bottom != client_height(*s))
-            resize_window(hwnd, *s);
         return 0;
     }
     case WM_DPICHANGED: {
         s->layout.update_for_dpi(HIWORD(wp));
         recreate_fonts(*s);
         auto* suggested = (RECT*)lp;
-        SetWindowPos(hwnd, nullptr, suggested->left, suggested->top, suggested->right - suggested->left,
-                     suggested->bottom - suggested->top, SWP_NOZORDER | SWP_NOACTIVATE);
+        // Move to the suggested position; WM_WINDOWPOSCHANGING will set the correct height.
+        SetWindowPos(hwnd, nullptr, suggested->left, suggested->top, 0, 0,
+                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
         resize_window(hwnd, *s);
         InvalidateRect(hwnd, nullptr, TRUE);
         return 0;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -134,6 +134,14 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         AdjustWindowRectEx(&adj_h, ws, FALSE, 0);
         m->ptMinTrackSize.y = adj_h.bottom - adj_h.top;
         m->ptMaxTrackSize.y = m->ptMinTrackSize.y;
+        m->ptMaxSize.y = m->ptMinTrackSize.y;
+        return 0;
+    }
+    case WM_WINDOWPOSCHANGED: {
+        RECT cr;
+        GetClientRect(hwnd, &cr);
+        if (cr.bottom != client_height(*s))
+            resize_window(hwnd, *s);
         return 0;
     }
     case WM_DPICHANGED: {

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -129,10 +129,10 @@ inline LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         s->layout.update_for_dpi(HIWORD(wp));
         recreate_fonts(*s);
         auto* suggested = (RECT*)lp;
-        // Move to the suggested position; WM_WINDOWPOSCHANGING will set the correct height.
-        SetWindowPos(hwnd, nullptr, suggested->left, suggested->top, 0, 0,
-                     SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
-        resize_window(hwnd, *s);
+        // Apply suggested position and DPI-scaled width; WM_WINDOWPOSCHANGING enforces the correct height.
+        SetWindowPos(hwnd, nullptr, suggested->left, suggested->top,
+                     suggested->right - suggested->left, suggested->bottom - suggested->top,
+                     SWP_NOZORDER | SWP_NOACTIVATE);
         InvalidateRect(hwnd, nullptr, TRUE);
         return 0;
     }


### PR DESCRIPTION
## Summary
- **`ptMaxSize.y` not set**: `WM_GETMINMAXINFO` constrained `ptMaxTrackSize.y` (max drag size) but left `ptMaxSize.y` at the monitor's default (full work-area height). Windows Snap and the DPI-change suggested-rect path could temporarily set the window to the monitor's work-area height before our `WM_SIZE` corrected it.
- **DWM non-client DPI lag**: With per-monitor-v2 DPI awareness, DWM updates the title bar/border size for the new monitor *after* `WM_DPICHANGED` returns. This sends another `WM_SIZE`, but the timing means `resize_window` inside `WM_DPICHANGED` samples the old non-client height, leaving the window a few pixels too tall until the follow-up `WM_SIZE` corrects it. Adding `WM_WINDOWPOSCHANGED` (fires after all compositing is settled) as a second safety net catches this case.

## Test plan
- [ ] Drag the app from a landscape monitor to a portrait (vertical/rotated) monitor — verify no extra space at the bottom
- [ ] If the monitors have different DPI settings, repeat the drag in both directions
- [ ] Verify the window cannot be maximized to fill the screen (drag title bar to top of monitor — snap should be constrained)
- [ ] Verify normal resize/move on a single monitor still works correctly

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Window height is enforced earlier during resizing, preventing unexpected height jumps.
  * DPI changes no longer produce sizing glitches — window now moves/resizes to the suggested scaled position.
  * Minimum width is respected reliably; redundant post-resize checks removed to reduce flicker and improve resize smoothness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/350)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->