### PR TITLE
refactor: reduce complexity — clear wins, atomic commits

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -130,6 +130,77 @@ struct HandleResult {
     bool open_alarm_dialog = false;
 };
 
+inline HandleResult dispatch_timer_action(App& app, int idx, int off,
+                                           std::chrono::steady_clock::time_point now) {
+    using namespace std::chrono;
+    HandleResult r;
+    if (idx < 0 || idx >= (int)app.timers.size()) return r;
+    auto& ts = app.timers[idx];
+
+    if (off == A_TMR_START) {
+        if (!ts.t.touched()) {
+            if (ts.dur.count() > 0) ts.t.start(now);
+        } else if (ts.t.is_running())
+            ts.t.pause(now);
+        else
+            ts.t.start(now);
+    } else if (off == A_TMR_RST) {
+        reset_timer_slot(ts, app);
+    } else if (off == A_TMR_ADD) {
+        if ((int)app.timers.size() < Config::MAX_TIMERS) {
+            TimerSlot ns;
+            ns.t.set(ns.dur);
+            app.timers.insert(app.timers.begin() + idx + 1, ns);
+            r.resize = true;
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_DEL) {
+        if ((int)app.timers.size() > 1) {
+            app.timers.erase(app.timers.begin() + idx);
+            r.resize = true;
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_POMO) {
+        if (!ts.t.touched()) {
+            if (ts.pomodoro) {
+                ts.pomodoro = false;
+                ts.label.clear();
+            } else {
+                ts.pomodoro = true;
+                ts.pomodoro_phase = 0;
+                ts.pomodoro_work_elapsed = {};
+                ts.dur = seconds{app.pomodoro_work_secs};
+                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
+                ts.notified = false;
+                ts.t.reset();
+                ts.t.set(ts.dur);
+            }
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_SKIP) {
+        if (ts.pomodoro && ts.t.touched()) {
+            if (pomodoro_is_work(ts.pomodoro_phase)) {
+                auto elapsed = duration_cast<seconds>(ts.t.total_elapsed(now));
+                ts.pomodoro_work_elapsed += elapsed;
+            }
+            ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, app.pomodoro_cadence);
+            auto secs = seconds{pomodoro_phase_secs(ts.pomodoro_phase,
+                app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs,
+                app.pomodoro_cadence)};
+            ts.dur = secs;
+            ts.notified = false;
+            ts.t.reset();
+            ts.t.set(secs);
+            ts.t.start(now);
+            ts.label = pomodoro_phase_label(ts.pomodoro_phase, app.pomodoro_cadence);
+            r.save_config = true;
+        }
+    } else if (!ts.t.touched() && apply_timer_hms_adjust(ts, off)) {
+        r.save_config = true;
+    }
+    return r;
+}
+
 inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock::time_point now,
                                      const std::filesystem::path& config_dir) {
     using namespace std::chrono;
@@ -251,69 +322,7 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         } else if (act >= A_TMR_BASE) {
             int idx = (act - A_TMR_BASE) / TMR_STRIDE;
             int off = (act - A_TMR_BASE) % TMR_STRIDE;
-            if (idx < 0 || idx >= (int)app.timers.size()) break;
-            auto& ts = app.timers[idx];
-            if (off == A_TMR_START) {
-                if (!ts.t.touched()) {
-                    if (ts.dur.count() > 0) ts.t.start(now);
-                } else if (ts.t.is_running())
-                    ts.t.pause(now);
-                else
-                    ts.t.start(now);
-            } else if (off == A_TMR_RST) {
-                reset_timer_slot(ts, app);
-            } else if (off == A_TMR_ADD) {
-                if ((int)app.timers.size() < Config::MAX_TIMERS) {
-                    TimerSlot ns;
-                    ns.t.set(ns.dur);
-                    app.timers.insert(app.timers.begin() + idx + 1, ns);
-                    r.resize = true;
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_DEL) {
-                if ((int)app.timers.size() > 1) {
-                    app.timers.erase(app.timers.begin() + idx);
-                    r.resize = true;
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_POMO) {
-                if (!ts.t.touched()) {
-                    if (ts.pomodoro) {
-                        ts.pomodoro = false;
-                        ts.label.clear();
-                    } else {
-                        ts.pomodoro = true;
-                        ts.pomodoro_phase = 0;
-                        ts.pomodoro_work_elapsed = {};
-                        ts.dur = seconds{app.pomodoro_work_secs};
-                        ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                        ts.notified = false;
-                        ts.t.reset();
-                        ts.t.set(ts.dur);
-                    }
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_SKIP) {
-                if (ts.pomodoro && ts.t.touched()) {
-                    if (pomodoro_is_work(ts.pomodoro_phase)) {
-                        auto elapsed = duration_cast<seconds>(ts.t.total_elapsed(now));
-                        ts.pomodoro_work_elapsed += elapsed;
-                    }
-                    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, app.pomodoro_cadence);
-                    auto secs = seconds{pomodoro_phase_secs(ts.pomodoro_phase,
-                        app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs,
-                        app.pomodoro_cadence)};
-                    ts.dur = secs;
-                    ts.notified = false;
-                    ts.t.reset();
-                    ts.t.set(secs);
-                    ts.t.start(now);
-                    ts.label = pomodoro_phase_label(ts.pomodoro_phase, app.pomodoro_cadence);
-                    r.save_config = true;
-                }
-            } else if (!ts.t.touched() && apply_timer_hms_adjust(ts, off)) {
-                r.save_config = true;
-            }
+            r = dispatch_timer_action(app, idx, off, now);
         }
     }
     return r;

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -47,6 +47,18 @@ constexpr int A_TMR_DEL = 9;
 constexpr int A_TMR_POMO = 10;
 constexpr int A_TMR_SKIP = 11;
 
+inline void reset_timer_slot(TimerSlot& ts, const App& app) {
+    ts.notified = false;
+    if (ts.pomodoro) {
+        ts.pomodoro_phase = 0;
+        ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
+        ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
+        ts.pomodoro_work_elapsed = {};
+    }
+    ts.t.reset();
+    ts.t.set(ts.dur);
+}
+
 inline bool apply_timer_hms_adjust(TimerSlot& ts, int off) {
     auto total = ts.dur.count();
     int h = (int)(total / 3600);
@@ -218,17 +230,8 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         r.open_alarm_dialog = true;
         break;
     case A_TMR_RST_ALL:
-        for (auto& ts : app.timers) {
-            ts.notified = false;
-            if (ts.pomodoro) {
-                ts.pomodoro_phase = 0;
-                ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
-                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                ts.pomodoro_work_elapsed = {};
-            }
-            ts.t.reset();
-            ts.t.set(ts.dur);
-        }
+        for (auto& ts : app.timers)
+            reset_timer_slot(ts, app);
         r.save_config = true;
         break;
     default:
@@ -258,15 +261,7 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
                 else
                     ts.t.start(now);
             } else if (off == A_TMR_RST) {
-                ts.notified = false;
-                if (ts.pomodoro) {
-                    ts.pomodoro_phase = 0;
-                    ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
-                    ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                    ts.pomodoro_work_elapsed = {};
-                }
-                ts.t.reset();
-                ts.t.set(ts.dur);
+                reset_timer_slot(ts, app);
             } else if (off == A_TMR_ADD) {
                 if ((int)app.timers.size() < Config::MAX_TIMERS) {
                     TimerSlot ns;

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -44,30 +44,8 @@ struct Params {
 
 // ─── Template builder ─────────────────────────────────────────────────────────
 
-struct Buf {
-    std::vector<WORD> data;
-    void align4() { while (data.size() % 2) data.push_back(0); }
-    void push_word(WORD w)   { data.push_back(w); }
-    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
-    void push_wstr_empty() { data.push_back(0); }
-};
-
-inline void add_item(Buf& b, DWORD style, short x, short y, short cx, short cy,
-                     WORD id, WORD cls_atom, const wchar_t* title) {
-    b.align4();
-    b.push_dword(WS_CHILD | WS_VISIBLE | style);
-    b.push_dword(0); // exStyle
-    b.push_word((WORD)x); b.push_word((WORD)y);
-    b.push_word((WORD)cx); b.push_word((WORD)cy);
-    b.push_word(id);
-    b.push_word(0xFFFF); b.push_word(cls_atom);
-    b.push_wstr(title);
-    b.push_word(0);
-}
-
 inline std::vector<WORD> build_template() {
-    Buf b;
+    DlgBuf b;
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);
     b.push_word(CTRL_COUNT);
@@ -78,23 +56,23 @@ inline std::vector<WORD> build_template() {
     b.push_wstr_empty(); // caption (painted)
 
     // Name edit  (x=46 y=25 w=148 h=11)
-    add_item(b, ES_AUTOHSCROLL | WS_TABSTOP, 46, 25, 148, 11, IDC_ALM_NAME, CLS_EDIT, L"");
+    dlg_add_item(b, ES_AUTOHSCROLL | WS_TABSTOP, 46, 25, 148, 11, IDC_ALM_NAME, CLS_EDIT, L"");
     // Hour edit  (x=46 y=40 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 46, 40, 22, 11, IDC_ALM_HOUR, CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 46, 40, 22, 11, IDC_ALM_HOUR, CLS_EDIT, L"");
     // Min edit   (x=78 y=40 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 78, 40, 22, 11, IDC_ALM_MIN,  CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 78, 40, 22, 11, IDC_ALM_MIN,  CLS_EDIT, L"");
 
     // Date fields: Year (x=36 y=70 w=38 h=11), Month (x=104 y=70 w=22 h=11), Day (x=158 y=70 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 36, 70, 38, 11, IDC_ALM_YEAR,  CLS_EDIT, L"");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 104, 70, 22, 11, IDC_ALM_MONTH, CLS_EDIT, L"");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 158, 70, 22, 11, IDC_ALM_DAY,   CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 36, 70, 38, 11, IDC_ALM_YEAR,  CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 104, 70, 22, 11, IDC_ALM_MONTH, CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 158, 70, 22, 11, IDC_ALM_DAY,   CLS_EDIT, L"");
 
     // OK / Cancel (owner-draw)
     constexpr short btn_w = 44, btn_h = 16;
     constexpr short btn_y = 118;
     constexpr short btn_x0 = (DLG_W - 2 * btn_w - 8) / 2;
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0, btn_y, btn_w, btn_h, IDC_ALM_OK,     CLS_BUTTON, L"OK");
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0 + btn_w + 8, btn_y, btn_w, btn_h, IDC_ALM_CANCEL, CLS_BUTTON, L"Cancel");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0, btn_y, btn_w, btn_h, IDC_ALM_OK,     CLS_BUTTON, L"OK");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0 + btn_w + 8, btn_y, btn_w, btn_h, IDC_ALM_CANCEL, CLS_BUTTON, L"Cancel");
 
     return b.data;
 }

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -37,6 +37,9 @@ struct Params {
     RECT rc_days_btn{};
     RECT rc_date_btn{};
     RECT rc_day[7]{};  // Mon-Sun painted toggles
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
 };
 
 // ─── Template builder ─────────────────────────────────────────────────────────
@@ -164,6 +167,9 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         }
 
         init_painted_rects(dlg, *p);
+        p->brush_bg   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+        p->brush_edit = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+        p->brush_btn  = GdiObj{CreateSolidBrush(p->style.theme->bg)};
 
         // Set fonts on all children
         EnumChildWindows(dlg, [](HWND ch, LPARAM par) -> BOOL {
@@ -253,30 +259,19 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
 
     case WM_CTLCOLORSTATIC: {
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkMode((HDC)wp, TRANSPARENT);
+        return (INT_PTR)p->brush_bg.h;
     }
     case WM_CTLCOLOREDIT: {
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkColor((HDC)wp, p->style.theme->bar);
+        return (INT_PTR)p->brush_edit.h;
     }
     case WM_CTLCOLORBTN: {
         if (!p) break;
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
+        return (INT_PTR)p->brush_btn.h;
     }
 
     case WM_NCHITTEST: {

--- a/src/config_serial.hpp
+++ b/src/config_serial.hpp
@@ -10,6 +10,37 @@
 
 #include "config.hpp"
 
+inline void write_analog_style(const AnalogClockStyle& a, std::ostream& f) {
+    AnalogClockStyle def;
+    if (a.hour_color != def.hour_color)             f << std::format("analog_hour_color={}\n",         a.hour_color);
+    if (a.minute_color != def.minute_color)         f << std::format("analog_minute_color={}\n",       a.minute_color);
+    if (a.second_color != def.second_color)         f << std::format("analog_second_color={}\n",       a.second_color);
+    if (a.face_color != def.face_color)             f << std::format("analog_face_color={}\n",         a.face_color);
+    if (a.tick_color != def.tick_color)             f << std::format("analog_tick_color={}\n",         a.tick_color);
+    if (a.background_color != def.background_color) f << std::format("analog_background_color={}\n",   a.background_color);
+    if (a.face_fill_color != def.face_fill_color)   f << std::format("analog_face_fill_color={}\n",    a.face_fill_color);
+    if (a.face_outline_color != def.face_outline_color) f << std::format("analog_face_outline_color={}\n", a.face_outline_color);
+    if (a.hour_label_color != def.hour_label_color) f << std::format("analog_hour_label_color={}\n",   a.hour_label_color);
+    if (a.center_dot_color != def.center_dot_color) f << std::format("analog_center_dot_color={}\n",   a.center_dot_color);
+    if (a.hour_len_pct != def.hour_len_pct)         f << std::format("analog_hour_len={}\n",           a.hour_len_pct);
+    if (a.minute_len_pct != def.minute_len_pct)     f << std::format("analog_minute_len={}\n",         a.minute_len_pct);
+    if (a.second_len_pct != def.second_len_pct)     f << std::format("analog_second_len={}\n",         a.second_len_pct);
+    if (a.hour_thickness != def.hour_thickness)     f << std::format("analog_hour_thick={}\n",         a.hour_thickness);
+    if (a.minute_thickness != def.minute_thickness) f << std::format("analog_minute_thick={}\n",       a.minute_thickness);
+    if (a.second_thickness != def.second_thickness) f << std::format("analog_second_thick={}\n",       a.second_thickness);
+    if (a.hour_tick_pct != def.hour_tick_pct)       f << std::format("analog_hour_tick={}\n",          a.hour_tick_pct);
+    if (a.minute_tick_pct != def.minute_tick_pct)   f << std::format("analog_minute_tick={}\n",        a.minute_tick_pct);
+    if (a.center_dot_size != def.center_dot_size)   f << std::format("analog_center_dot_size={}\n",    a.center_dot_size);
+    if (a.hour_opacity_pct != def.hour_opacity_pct) f << std::format("analog_hour_opacity={}\n",       a.hour_opacity_pct);
+    if (a.minute_opacity_pct != def.minute_opacity_pct) f << std::format("analog_minute_opacity={}\n", a.minute_opacity_pct);
+    if (a.second_opacity_pct != def.second_opacity_pct) f << std::format("analog_second_opacity={}\n", a.second_opacity_pct);
+    if (a.tick_opacity_pct != def.tick_opacity_pct) f << std::format("analog_tick_opacity={}\n",       a.tick_opacity_pct);
+    if (a.face_opacity_pct != def.face_opacity_pct) f << std::format("analog_face_opacity={}\n",       a.face_opacity_pct);
+    if (a.radius_pct != def.radius_pct)             f << std::format("analog_radius={}\n",             a.radius_pct);
+    if (a.show_minute_ticks != def.show_minute_ticks) f << std::format("analog_show_min_ticks={}\n",   a.show_minute_ticks ? 1 : 0);
+    if (a.hour_labels != def.hour_labels)           f << std::format("analog_hour_labels={}\n",        (int)a.hour_labels);
+}
+
 inline bool config_write(const Config& c, std::ostream& f) {
     const char* theme_str = c.theme_mode == ThemeMode::Dark ? "dark" : c.theme_mode == ThemeMode::Light ? "light" : "auto";
     f << std::format("show_clk={}\nshow_sw={}\nshow_tmr={}\ntopmost={}\nsound_on_expiry={}\ntheme={}\nclock_view={}\nnum_timers={}\n", c.show_clk ? 1 : 0,
@@ -40,37 +71,7 @@ inline bool config_write(const Config& c, std::ostream& f) {
         f << std::format("pomodoro_cadence={}\n", c.pomodoro_cadence);
     if (c.pomodoro_auto_start != defaults.pomodoro_auto_start)
         f << std::format("pomodoro_auto_start={}\n", c.pomodoro_auto_start ? 1 : 0);
-    {
-        const auto& a = c.analog_style;
-        AnalogClockStyle def;
-        if (a.hour_color != def.hour_color) f << std::format("analog_hour_color={}\n", a.hour_color);
-        if (a.minute_color != def.minute_color) f << std::format("analog_minute_color={}\n", a.minute_color);
-        if (a.second_color != def.second_color) f << std::format("analog_second_color={}\n", a.second_color);
-        if (a.face_color != def.face_color) f << std::format("analog_face_color={}\n", a.face_color);
-        if (a.tick_color != def.tick_color) f << std::format("analog_tick_color={}\n", a.tick_color);
-        if (a.background_color != def.background_color) f << std::format("analog_background_color={}\n", a.background_color);
-        if (a.face_fill_color != def.face_fill_color) f << std::format("analog_face_fill_color={}\n", a.face_fill_color);
-        if (a.face_outline_color != def.face_outline_color) f << std::format("analog_face_outline_color={}\n", a.face_outline_color);
-        if (a.hour_label_color != def.hour_label_color) f << std::format("analog_hour_label_color={}\n", a.hour_label_color);
-        if (a.center_dot_color != def.center_dot_color) f << std::format("analog_center_dot_color={}\n", a.center_dot_color);
-        if (a.hour_len_pct != def.hour_len_pct) f << std::format("analog_hour_len={}\n", a.hour_len_pct);
-        if (a.minute_len_pct != def.minute_len_pct) f << std::format("analog_minute_len={}\n", a.minute_len_pct);
-        if (a.second_len_pct != def.second_len_pct) f << std::format("analog_second_len={}\n", a.second_len_pct);
-        if (a.hour_thickness != def.hour_thickness) f << std::format("analog_hour_thick={}\n", a.hour_thickness);
-        if (a.minute_thickness != def.minute_thickness) f << std::format("analog_minute_thick={}\n", a.minute_thickness);
-        if (a.second_thickness != def.second_thickness) f << std::format("analog_second_thick={}\n", a.second_thickness);
-        if (a.hour_tick_pct != def.hour_tick_pct) f << std::format("analog_hour_tick={}\n", a.hour_tick_pct);
-        if (a.minute_tick_pct != def.minute_tick_pct) f << std::format("analog_minute_tick={}\n", a.minute_tick_pct);
-        if (a.center_dot_size != def.center_dot_size) f << std::format("analog_center_dot_size={}\n", a.center_dot_size);
-        if (a.hour_opacity_pct != def.hour_opacity_pct) f << std::format("analog_hour_opacity={}\n", a.hour_opacity_pct);
-        if (a.minute_opacity_pct != def.minute_opacity_pct) f << std::format("analog_minute_opacity={}\n", a.minute_opacity_pct);
-        if (a.second_opacity_pct != def.second_opacity_pct) f << std::format("analog_second_opacity={}\n", a.second_opacity_pct);
-        if (a.tick_opacity_pct != def.tick_opacity_pct) f << std::format("analog_tick_opacity={}\n", a.tick_opacity_pct);
-        if (a.face_opacity_pct != def.face_opacity_pct) f << std::format("analog_face_opacity={}\n", a.face_opacity_pct);
-        if (a.radius_pct != def.radius_pct) f << std::format("analog_radius={}\n", a.radius_pct);
-        if (a.show_minute_ticks != def.show_minute_ticks) f << std::format("analog_show_min_ticks={}\n", a.show_minute_ticks ? 1 : 0);
-        if (a.hour_labels != def.hour_labels) f << std::format("analog_hour_labels={}\n", (int)a.hour_labels);
-    }
+    write_analog_style(c.analog_style, f);
     if (c.num_custom_presets > 0) {
         f << std::format("num_custom_presets={}\n", c.num_custom_presets);
         for (int i = 0; i < c.num_custom_presets; ++i)

--- a/src/dialog_style.hpp
+++ b/src/dialog_style.hpp
@@ -1,9 +1,34 @@
 #pragma once
+#include <vector>
 #include <windows.h>
 #include "dwm_fwd.hpp"
 #include "gdi.hpp"
 #include "layout.hpp"
 #include "theme.hpp"
+
+// ─── Runtime DLGTEMPLATE builder ─────────────────────────────────────────────
+
+struct DlgBuf {
+    std::vector<WORD> data;
+    void align4() { while (data.size() % 2) data.push_back(0); }
+    void push_word(WORD w)   { data.push_back(w); }
+    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
+    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
+    void push_wstr_empty() { data.push_back(0); }
+};
+
+inline void dlg_add_item(DlgBuf& b, DWORD style, short x, short y, short cx, short cy,
+                          WORD id, WORD cls_atom, const wchar_t* title) {
+    b.align4();
+    b.push_dword(WS_CHILD | WS_VISIBLE | style);
+    b.push_dword(0);
+    b.push_word((WORD)x); b.push_word((WORD)y);
+    b.push_word((WORD)cx); b.push_word((WORD)cy);
+    b.push_word(id);
+    b.push_word(0xFFFF); b.push_word(cls_atom);
+    b.push_wstr(title);
+    b.push_word(0);
+}
 
 // Reusable owner-drawn dialog styling for Chronos dialogs.
 // Ensures popups share the same visual language as the main window.

--- a/src/input_keyboard.hpp
+++ b/src/input_keyboard.hpp
@@ -15,23 +15,22 @@ inline bool plain_key() {
         && GetKeyState(VK_RWIN) >= 0;
 }
 
+inline void trigger_start(HWND hwnd, WndState& s) {
+    if (s.app.show_sw)
+        handle(hwnd, A_SW_START, s);
+    else if (s.app.show_tmr && !s.app.timers.empty())
+        handle(hwnd, tmr_act(0, A_TMR_START), s);
+}
+
 inline std::optional<LRESULT> dispatch_keyboard(HWND hwnd, UINT msg, WPARAM wp, WndState& s) {
     switch (msg) {
     case WM_HOTKEY:
-        if (wp == HOTKEY_GLOBAL) {
-            if (s.app.show_sw)
-                handle(hwnd, A_SW_START, s);
-            else if (s.app.show_tmr && !s.app.timers.empty())
-                handle(hwnd, tmr_act(0, A_TMR_START), s);
-        }
+        if (wp == HOTKEY_GLOBAL) trigger_start(hwnd, s);
         return 0;
     case WM_KEYDOWN:
         switch (wp) {
         case VK_SPACE:
-            if (s.app.show_sw)
-                handle(hwnd, A_SW_START, s);
-            else if (s.app.show_tmr && !s.app.timers.empty())
-                handle(hwnd, tmr_act(0, A_TMR_START), s);
+            trigger_start(hwnd, s);
             return 0;
         case 'L':
             if (plain_key() && s.app.show_sw) handle(hwnd, A_SW_LAP, s);

--- a/src/input_mouse.hpp
+++ b/src/input_mouse.hpp
@@ -18,6 +18,22 @@
 #include "timer_presets.hpp"
 #include "wndstate.hpp"
 
+constexpr int CMD_POMODORO    = 100;
+constexpr int CMD_POMO_CFG    = 101;
+constexpr int CMD_CUSTOM_BASE = 200;
+
+inline void apply_timer_seconds(HWND hwnd, WndState& s, int idx, int secs) {
+    auto& ts = s.app.timers[idx];
+    ts.pomodoro = false;
+    ts.label.clear();
+    ts.dur = std::chrono::seconds{secs};
+    ts.notified = false;
+    ts.t.reset();
+    ts.t.set(ts.dur);
+    save_config(hwnd, s);
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp, WndState& s) {
     switch (msg) {
     case WM_LBUTTONDOWN: {
@@ -46,9 +62,6 @@ inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPA
         POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         int idx = timer_index_at_y(s.layout, layout_state(s), pt.y);
         if (idx >= 0 && !s.app.timers[idx].t.touched()) {
-            constexpr int CMD_POMODORO = 100;
-            constexpr int CMD_POMO_CFG = 101;
-            constexpr int CMD_CUSTOM_BASE = 200;
             HMENU menu = CreatePopupMenu();
             for (int i = 0; i < (int)std::size(TIMER_PRESETS); ++i) AppendMenuW(menu, MF_STRING, 1 + i, TIMER_PRESETS[i].label);
             if (!s.app.custom_preset_secs.empty()) {
@@ -90,23 +103,9 @@ inline std::optional<LRESULT> dispatch_mouse(HWND hwnd, UINT msg, WPARAM wp, LPA
                     }
                 } else if (cmd >= CMD_CUSTOM_BASE &&
                            cmd < CMD_CUSTOM_BASE + (int)s.app.custom_preset_secs.size()) {
-                    ts.pomodoro = false;
-                    ts.label.clear();
-                    ts.dur = std::chrono::seconds{s.app.custom_preset_secs[cmd - CMD_CUSTOM_BASE]};
-                    ts.notified = false;
-                    ts.t.reset();
-                    ts.t.set(ts.dur);
-                    save_config(hwnd, s);
-                    InvalidateRect(hwnd, nullptr, FALSE);
+                    apply_timer_seconds(hwnd, s, idx, s.app.custom_preset_secs[cmd - CMD_CUSTOM_BASE]);
                 } else {
-                    ts.pomodoro = false;
-                    ts.label.clear();
-                    ts.dur = std::chrono::seconds{TIMER_PRESETS[cmd - 1].secs};
-                    ts.notified = false;
-                    ts.t.reset();
-                    ts.t.set(ts.dur);
-                    save_config(hwnd, s);
-                    InvalidateRect(hwnd, nullptr, FALSE);
+                    apply_timer_seconds(hwnd, s, idx, TIMER_PRESETS[cmd - 1].secs);
                 }
             }
         }

--- a/src/painting.hpp
+++ b/src/painting.hpp
@@ -127,17 +127,17 @@ inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
     auto& th = ctx.theme;
     divider(hdc, y, cw, ctx);
 
-    int pad = layout.dpi_scale(10);
-    int bw  = layout.dpi_scale(56);
-    int bh  = layout.dpi_scale(24);
-    int by0 = y + (layout.alarm_header_h - bh) / 2;
+    int pad          = layout.dpi_scale(10);
+    int add_btn_w    = layout.dpi_scale(56);
+    int btn_h        = layout.dpi_scale(24);
+    int header_btn_y = y + (layout.alarm_header_h - btn_h) / 2;
 
     SelectObject(hdc, ctx.res.fontSm);
     SetTextColor(hdc, th.text);
-    RECT title_r{pad, y, cw - bw - 2 * pad, y + layout.alarm_header_h};
+    RECT title_r{pad, y, cw - add_btn_w - 2 * pad, y + layout.alarm_header_h};
     DrawTextW(hdc, L"Alarms", -1, &title_r, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
 
-    btn(hdc, {cw - bw - pad, by0, cw - pad, by0 + bh}, false, L"+ Add", A_ALARM_ADD, ctx);
+    btn(hdc, {cw - add_btn_w - pad, header_btn_y, cw - pad, header_btn_y + btn_h}, false, L"+ Add", A_ALARM_ADD, ctx);
 
     int row_y = y + layout.alarm_header_h;
     int del_w = layout.dpi_scale(36);
@@ -182,10 +182,10 @@ inline int paint_alarms(HDC hdc, int cw, int y, PaintCtx& ctx) {
         SetTextColor(hdc, a.enabled ? th.text : th.dim);
         DrawTextW(hdc, label.c_str(), -1, &lr, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS);
 
-        int btn_top = row_mid - bh / 2;
-        btn(hdc, {tog_x, btn_top, tog_x + tog_w, btn_top + bh},
+        int btn_top = row_mid - btn_h / 2;
+        btn(hdc, {tog_x, btn_top, tog_x + tog_w, btn_top + btn_h},
             a.enabled, a.enabled ? L"On" : L"Off", A_ALARM_TOGGLE + i, ctx);
-        btn(hdc, {del_x, btn_top, del_x + del_w, btn_top + bh},
+        btn(hdc, {del_x, btn_top, del_x + del_w, btn_top + btn_h},
             false, L"Del", A_ALARM_DEL + i, ctx);
 
         row_y += layout.alarm_row_h;

--- a/src/painting_timer.hpp
+++ b/src/painting_timer.hpp
@@ -40,15 +40,15 @@ inline void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     auto& th = ctx.theme;
     auto& ts = ctx.app.timers[i];
     auto m = TimerMetrics::from(layout);
-    int hh_cx = cw / 2 - m.col_gap, mm_cx = cw / 2, ss_cx = cw / 2 + m.col_gap;
+    int hour_cx = cw / 2 - m.col_gap, min_cx = cw / 2, sec_cx = cw / 2 + m.col_gap;
 
     SelectObject(hdc, ctx.res.fontSm);
     if (!ts.pomodoro) {
-        btn(hdc, {hh_cx - m.abw / 2, y + m.up_off, hh_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
+        btn(hdc, {hour_cx - m.abw / 2, y + m.up_off, hour_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
             tmr_act(i, A_TMR_HUP), ctx);
-        btn(hdc, {mm_cx - m.abw / 2, y + m.up_off, mm_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
+        btn(hdc, {min_cx - m.abw / 2, y + m.up_off, min_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
             tmr_act(i, A_TMR_MUP), ctx);
-        btn(hdc, {ss_cx - m.abw / 2, y + m.up_off, ss_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
+        btn(hdc, {sec_cx - m.abw / 2, y + m.up_off, sec_cx + m.abw / 2, y + m.up_off + m.abh}, false, L"\u25B2",
             tmr_act(i, A_TMR_SUP), ctx);
     }
 
@@ -78,24 +78,24 @@ inline void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     } else {
         SelectObject(hdc, ctx.res.fontBig);
         SetTextColor(hdc, th.text);
-        int field_h    = layout.dpi_scale(40);
-        int td_y       = y + m.td_off;
-        int field_half = layout.dpi_scale(22);
+        int field_h      = layout.dpi_scale(40);
+        int field_top    = y + m.td_off;
+        int field_half_w = layout.dpi_scale(22);
         long long total_s_edit = ts.dur.count();
         auto h_s  = std::format(L"{}", total_s_edit / 3600);
         auto mm_s = std::format(L"{:02}", (total_s_edit / 60) % 60);
         auto ss_s = std::format(L"{:02}", total_s_edit % 60);
-        RECT hr{hh_cx - field_half, td_y, hh_cx + field_half, td_y + field_h};
-        RECT mr{mm_cx - field_half, td_y, mm_cx + field_half, td_y + field_h};
-        RECT sr{ss_cx - field_half, td_y, ss_cx + field_half, td_y + field_h};
+        RECT hr{hour_cx - field_half_w, field_top, hour_cx + field_half_w, field_top + field_h};
+        RECT mr{min_cx  - field_half_w, field_top, min_cx  + field_half_w, field_top + field_h};
+        RECT sr{sec_cx  - field_half_w, field_top, sec_cx  + field_half_w, field_top + field_h};
         DrawTextW(hdc, h_s.c_str(), -1, &hr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         DrawTextW(hdc, mm_s.c_str(), -1, &mr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         DrawTextW(hdc, ss_s.c_str(), -1, &sr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         int sep_w   = layout.dpi_scale(8);
-        int sep1_cx = (hh_cx + mm_cx) / 2;
-        int sep2_cx = (mm_cx + ss_cx) / 2;
-        RECT sep1r{sep1_cx - sep_w / 2, td_y, sep1_cx + sep_w / 2, td_y + field_h};
-        RECT sep2r{sep2_cx - sep_w / 2, td_y, sep2_cx + sep_w / 2, td_y + field_h};
+        int sep1_cx = (hour_cx + min_cx) / 2;
+        int sep2_cx = (min_cx  + sec_cx) / 2;
+        RECT sep1r{sep1_cx - sep_w / 2, field_top, sep1_cx + sep_w / 2, field_top + field_h};
+        RECT sep2r{sep2_cx - sep_w / 2, field_top, sep2_cx + sep_w / 2, field_top + field_h};
         DrawTextW(hdc, L":", -1, &sep1r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         DrawTextW(hdc, L":", -1, &sep2r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
     }
@@ -103,11 +103,11 @@ inline void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     SelectObject(hdc, ctx.res.fontSm);
     SetTextColor(hdc, th.text);
     if (!ts.pomodoro) {
-        btn(hdc, {hh_cx - m.abw / 2, y + m.dn_off, hh_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
+        btn(hdc, {hour_cx - m.abw / 2, y + m.dn_off, hour_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
             tmr_act(i, A_TMR_HDN), ctx);
-        btn(hdc, {mm_cx - m.abw / 2, y + m.dn_off, mm_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
+        btn(hdc, {min_cx - m.abw / 2, y + m.dn_off, min_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
             tmr_act(i, A_TMR_MDN), ctx);
-        btn(hdc, {ss_cx - m.abw / 2, y + m.dn_off, ss_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
+        btn(hdc, {sec_cx - m.abw / 2, y + m.dn_off, sec_cx + m.abw / 2, y + m.dn_off + m.abh}, false, L"\u25BC",
             tmr_act(i, A_TMR_SDN), ctx);
     }
 }
@@ -141,7 +141,7 @@ inline void paint_timer_controls(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     auto& layout = ctx.layout;
     auto& ts = ctx.app.timers[i];
     int gap = layout.dpi_scale(6), bh = layout.dpi_scale(28);
-    int by_off = layout.tmr_h - bh;
+    int btn_bot_off = layout.tmr_h - bh;
     bool running = ts.t.is_running();
 
     SelectObject(hdc, ctx.res.fontSm);
@@ -149,18 +149,18 @@ inline void paint_timer_controls(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     if (ts.pomodoro) {
         int cw3 = layout.dpi_scale(58);
         int cx0 = (cw - 3 * cw3 - 2 * gap) / 2;
-        btn(hdc, {cx0, y + by_off, cx0 + cw3, y + by_off + bh}, running, running ? L"Pause" : L"Start",
+        btn(hdc, {cx0, y + btn_bot_off, cx0 + cw3, y + btn_bot_off + bh}, running, running ? L"Pause" : L"Start",
             tmr_act(i, A_TMR_START), ctx);
-        btn(hdc, {cx0 + cw3 + gap, y + by_off, cx0 + 2 * cw3 + gap, y + by_off + bh}, false, L"Skip",
+        btn(hdc, {cx0 + cw3 + gap, y + btn_bot_off, cx0 + 2 * cw3 + gap, y + btn_bot_off + bh}, false, L"Skip",
             tmr_act(i, A_TMR_SKIP), ctx);
-        btn(hdc, {cx0 + 2 * (cw3 + gap), y + by_off, cx0 + 3 * cw3 + 2 * gap, y + by_off + bh}, false, L"Reset",
+        btn(hdc, {cx0 + 2 * (cw3 + gap), y + btn_bot_off, cx0 + 3 * cw3 + 2 * gap, y + btn_bot_off + bh}, false, L"Reset",
             tmr_act(i, A_TMR_RST), ctx);
     } else {
         int cw2 = layout.dpi_scale(86);
         int cx0 = (cw - 2 * cw2 - gap) / 2;
-        btn(hdc, {cx0, y + by_off, cx0 + cw2, y + by_off + bh}, running, running ? L"Pause" : L"Start",
+        btn(hdc, {cx0, y + btn_bot_off, cx0 + cw2, y + btn_bot_off + bh}, running, running ? L"Pause" : L"Start",
             tmr_act(i, A_TMR_START), ctx);
-        btn(hdc, {cx0 + cw2 + gap, y + by_off, cx0 + 2 * cw2 + gap, y + by_off + bh}, false, L"Reset",
+        btn(hdc, {cx0 + cw2 + gap, y + btn_bot_off, cx0 + 2 * cw2 + gap, y + btn_bot_off + bh}, false, L"Reset",
             tmr_act(i, A_TMR_RST), ctx);
     }
 

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -115,6 +115,9 @@ inline std::vector<WORD> build_template() {
 struct Params {
     int work_min, short_min, long_min;
     DlgStyle style;
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
 };
 
 inline bool read_field(HWND dlg, int id, int& out) {
@@ -159,6 +162,10 @@ inline INT_PTR CALLBACK PomoDlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             return TRUE;
         }, (LPARAM)p);
 
+        p->brush_bg   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+        p->brush_edit = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+        p->brush_btn  = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+
         SetFocus(GetDlgItem(dlg, IDC_POMO_WORK));
         SendDlgItemMessageW(dlg, IDC_POMO_WORK, EM_SETSEL, 0, -1);
         return FALSE;
@@ -193,32 +200,21 @@ inline INT_PTR CALLBACK PomoDlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_CTLCOLORSTATIC: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkMode((HDC)wp, TRANSPARENT);
+        return (INT_PTR)p->brush_bg.h;
     }
     case WM_CTLCOLOREDIT: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkColor((HDC)wp, p->style.theme->bar);
+        return (INT_PTR)p->brush_edit.h;
     }
     case WM_CTLCOLORBTN: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
+        return (INT_PTR)p->brush_btn.h;
     }
     case WM_NCHITTEST: {
         RECT title_rc = {0, 0, DLG_W, 22};

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -2,7 +2,6 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <format>
-#include <vector>
 #include "app.hpp"
 #include "dialog_style.hpp"
 
@@ -22,35 +21,12 @@ constexpr WORD CLS_BUTTON = 0x0080;
 constexpr WORD CLS_EDIT   = 0x0081;
 constexpr WORD CLS_STATIC = 0x0082;
 
-struct Buf {
-    std::vector<WORD> data;
-    void align4() { while (data.size() % 2) data.push_back(0); }
-    void push_word(WORD w)  { data.push_back(w); }
-    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
-    void push_wstr_empty() { data.push_back(0); }
-};
-
-inline void add_item(Buf& b, DWORD style, DWORD exStyle,
-                     short x, short y, short cx, short cy,
-                     WORD id, WORD cls_atom, const wchar_t* title) {
-    b.align4();
-    b.push_dword(WS_CHILD | WS_VISIBLE | style);
-    b.push_dword(exStyle);
-    b.push_word((WORD)x);  b.push_word((WORD)y);
-    b.push_word((WORD)cx); b.push_word((WORD)cy);
-    b.push_word(id);
-    b.push_word(0xFFFF); b.push_word(cls_atom);
-    b.push_wstr(title);
-    b.push_word(0);
-}
-
 // 3 labels + 3 edits + 3 "min" statics + 2 buttons = 11
 constexpr WORD DLG_ITEM_COUNT = 11;
 constexpr short DLG_W = 170, DLG_H = 110;
 
 inline std::vector<WORD> build_template() {
-    Buf b;
+    DlgBuf b;
 
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);
@@ -72,40 +48,40 @@ inline std::vector<WORD> build_template() {
     short row_h = 12;
 
     // Row 0 — Work
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, row_y0, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Work");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, row_y0, ed_w, row_h, IDC_POMO_WORK, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, row_y0, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, row_y0, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Work");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, row_y0, ed_w, row_h, IDC_POMO_WORK, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, row_y0, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Row 1 — Short break
     short r1 = row_y0 + row_sp;
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, r1, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Short break");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, r1, ed_w, row_h, IDC_POMO_SHORT, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, r1, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, r1, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Short break");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, r1, ed_w, row_h, IDC_POMO_SHORT, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, r1, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Row 2 — Long break
     short r2 = row_y0 + 2 * row_sp;
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, r2, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Long break");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, r2, ed_w, row_h, IDC_POMO_LONG, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, r2, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, r2, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Long break");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, r2, ed_w, row_h, IDC_POMO_LONG, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, r2, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Buttons — centered at bottom
     short btn_y = row_y0 + 3 * row_sp + 4;
     short btn_w = 44, btn_h = 16, btn_gap = 8;
     short total_w = 2 * btn_w + btn_gap;
     short btn_x0 = (DLG_W - total_w) / 2;
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
-             btn_x0, btn_y, btn_w, btn_h, IDC_BTN_OK, CLS_BUTTON, L"OK");
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
-             btn_x0 + btn_w + btn_gap, btn_y, btn_w, btn_h, IDC_BTN_CANCEL, CLS_BUTTON, L"Cancel");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP,
+                 btn_x0, btn_y, btn_w, btn_h, IDC_BTN_OK, CLS_BUTTON, L"OK");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP,
+                 btn_x0 + btn_w + btn_gap, btn_y, btn_w, btn_h, IDC_BTN_CANCEL, CLS_BUTTON, L"Cancel");
 
     return b.data;
 }

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -258,6 +258,102 @@ static INT_PTR on_init(HWND dlg, LPARAM lp) {
     return FALSE;
 }
 
+static void paint_appearance_tab(HWND dlg, HDC hdc, const Params& p, int sdy) {
+    auto& s = p.style;
+    RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
+    lbl.top += sdy; lbl.bottom += sdy;
+    s.draw_label(hdc, lbl, L"Theme");
+
+    RECT slbl = map_dlu(dlg, 70, 88, 80, 8);
+    slbl.top += sdy; slbl.bottom += sdy;
+    s.draw_label(hdc, slbl, L"Notifications");
+}
+
+static void paint_analog_clock_tab(HWND dlg, HDC hdc, const Params& p, int sdy) {
+    auto& s = p.style;
+    RECT preview = p.rects.analog_preview;
+
+    {
+        int sdc2 = SaveDC(hdc);
+        ExcludeClipRect(hdc, preview.left, preview.top, preview.right, preview.bottom);
+
+        RECT min_r = p.rects.analog_min_ticks;
+        min_r.top += sdy; min_r.bottom += sdy;
+        paint_option_btn(hdc, min_r,
+                         p.analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
+                         p.analog_style.show_minute_ticks, s);
+
+        RECT hrlbl = map_dlu(dlg, 158, 82, 80, 8);
+        hrlbl.top += sdy; hrlbl.bottom += sdy;
+        s.draw_label(hdc, hrlbl, L"Hour labels");
+
+        const wchar_t* lbl_names[] = {L"None", L"Sparse", L"Full"};
+        for (int i = 0; i < 3; ++i) {
+            RECT ar = p.rects.analog_labels[i];
+            ar.top += sdy; ar.bottom += sdy;
+            paint_option_btn(hdc, ar, lbl_names[i], (int)p.analog_style.hour_labels == i, s);
+        }
+
+        RECT color_lbl = map_dlu(dlg, 158, 112, 80, 8);
+        color_lbl.top += sdy; color_lbl.bottom += sdy;
+        s.draw_label(hdc, color_lbl, L"Colors");
+        for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
+            RECT r = p.rects.analog_colors[i];
+            r.top += sdy; r.bottom += sdy;
+            int* field = analog_color_field(const_cast<AnalogClockStyle&>(p.analog_style), i);
+            bool custom = field && *field >= 0;
+            paint_option_btn(hdc, r, analog_color_label(i), custom, s);
+            RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
+            COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
+            GdiObj br{CreateSolidBrush(sw_color)};
+            FillRect(hdc, &sw, (HBRUSH)br.h);
+        }
+
+        RECT value_lbl = map_dlu(dlg, 68, 248, 200, 8);
+        value_lbl.top += sdy; value_lbl.bottom += sdy;
+        s.draw_label(hdc, value_lbl, L"Size and opacity");
+        for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
+            RECT r = p.rects.analog_values[i];
+            r.top += sdy; r.bottom += sdy;
+            int* field = analog_value_field(const_cast<AnalogClockStyle&>(p.analog_style), i);
+            wchar_t buf[96];
+            wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
+            paint_option_btn(hdc, r, buf, false, s);
+        }
+
+        RestoreDC(hdc, sdc2);
+    }
+
+    // Fixed preview drawn on top — no scroll offset
+    RECT prev_lbl = map_dlu(dlg, 68, 64, 80, 8);
+    s.draw_label(hdc, prev_lbl, L"Live preview");
+    draw_analog_clock(hdc, preview, p.analog_style, *s.theme, s.dpi, 10, 10, 30);
+}
+
+static void paint_clock_tab(HWND dlg, HDC hdc, const Params& p, int sdy) {
+    auto& s = p.style;
+    RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
+    lbl.top += sdy; lbl.bottom += sdy;
+    s.draw_label(hdc, lbl, L"Format");
+
+    if (p.clock_view == ClockView::Analog)
+        paint_analog_clock_tab(dlg, hdc, p, sdy);
+}
+
+static void paint_timers_tab(HWND dlg, HDC hdc, const Params& p, int sdy) {
+    auto& s = p.style;
+    RECT lbl = map_dlu(dlg, 70, 28, 100, 12);
+    lbl.top += sdy; lbl.bottom += sdy;
+    s.draw_label(hdc, lbl, L"Custom presets");
+
+    for (int i = 0; i < 5; ++i) {
+        RECT num = map_dlu(dlg, 76, (short)(40 + i * 16), 16, 12);
+        num.top += sdy; num.bottom += sdy;
+        auto txt = std::format(L"{}.", i + 1);
+        s.draw_label(hdc, num, txt.c_str());
+    }
+}
+
 static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
     auto* p = dialog_params(dlg);
     if (!p) return FALSE;
@@ -283,17 +379,13 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
 
     HPEN div_pen = CreatePen(PS_SOLID, 1, s.theme->divider);
     auto* old_pen = (HPEN)SelectObject(hdc, div_pen);
-
     MoveToEx(hdc, 0, div_y.bottom, nullptr);
     LineTo(hdc, rc.right, div_y.bottom);
-
     MoveToEx(hdc, sb.right, div_y.bottom, nullptr);
     LineTo(hdc, sb.right, rc.bottom);
-
     int btn_area_top = content_area_bottom(dlg);
     MoveToEx(hdc, sb.right, btn_area_top, nullptr);
     LineTo(hdc, rc.right, btn_area_top);
-
     SelectObject(hdc, old_pen);
     DeleteObject(div_pen);
 
@@ -303,96 +395,12 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
 
     int save_dc = SaveDC(hdc);
     IntersectClipRect(hdc, sb.right + 1, div_y.bottom + 1, rc.right, btn_area_top);
-
     int sdy = -p->scroll_y;
 
-    if (p->active_tab == TAB_APPEARANCE) {
-        RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
-        lbl.top += sdy; lbl.bottom += sdy;
-        s.draw_label(hdc, lbl, L"Theme");
-
-        RECT slbl = map_dlu(dlg, 70, 88, 80, 8);
-        slbl.top += sdy; slbl.bottom += sdy;
-        s.draw_label(hdc, slbl, L"Notifications");
-
-    } else if (p->active_tab == TAB_CLOCK) {
-        RECT lbl = map_dlu(dlg, 70, 28, 80, 12);
-        lbl.top += sdy; lbl.bottom += sdy;
-        s.draw_label(hdc, lbl, L"Format");
-
-        if (p->clock_view == ClockView::Analog) {
-            RECT preview = p->rects.analog_preview;
-
-            // Draw scrollable settings clipped to exclude the sticky preview region
-            {
-                int sdc2 = SaveDC(hdc);
-                ExcludeClipRect(hdc, preview.left, preview.top, preview.right, preview.bottom);
-
-                RECT min_r = p->rects.analog_min_ticks;
-                min_r.top += sdy; min_r.bottom += sdy;
-                paint_option_btn(hdc, min_r,
-                                 p->analog_style.show_minute_ticks ? L"Min ticks: on" : L"Min ticks: off",
-                                 p->analog_style.show_minute_ticks, s);
-
-                RECT hrlbl = map_dlu(dlg, 158, 82, 80, 8);
-                hrlbl.top += sdy; hrlbl.bottom += sdy;
-                s.draw_label(hdc, hrlbl, L"Hour labels");
-
-                const wchar_t* lbl_names[] = {L"None", L"Sparse", L"Full"};
-                for (int i = 0; i < 3; ++i) {
-                    RECT ar = p->rects.analog_labels[i];
-                    ar.top += sdy; ar.bottom += sdy;
-                    paint_option_btn(hdc, ar, lbl_names[i],
-                                     (int)p->analog_style.hour_labels == i, s);
-                }
-
-                RECT color_lbl = map_dlu(dlg, 158, 112, 80, 8);
-                color_lbl.top += sdy; color_lbl.bottom += sdy;
-                s.draw_label(hdc, color_lbl, L"Colors");
-                for (int i = 0; i < ANALOG_COLOR_COUNT; ++i) {
-                    RECT r = p->rects.analog_colors[i];
-                    r.top += sdy; r.bottom += sdy;
-                    int* field = analog_color_field(p->analog_style, i);
-                    bool custom = field && *field >= 0;
-                    paint_option_btn(hdc, r, analog_color_label(i), custom, s);
-                    RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
-                    COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
-                    GdiObj br{CreateSolidBrush(sw_color)};
-                    FillRect(hdc, &sw, (HBRUSH)br.h);
-                }
-
-                RECT value_lbl = map_dlu(dlg, 68, 248, 200, 8);
-                value_lbl.top += sdy; value_lbl.bottom += sdy;
-                s.draw_label(hdc, value_lbl, L"Size and opacity");
-                for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
-                    RECT r = p->rects.analog_values[i];
-                    r.top += sdy; r.bottom += sdy;
-                    int* field = analog_value_field(p->analog_style, i);
-                    wchar_t buf[96];
-                    wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
-                    paint_option_btn(hdc, r, buf, false, s);
-                }
-
-                RestoreDC(hdc, sdc2);
-            }
-
-            // Fixed preview drawn on top — no sdy offset
-            RECT prev_lbl = map_dlu(dlg, 68, 64, 80, 8);
-            s.draw_label(hdc, prev_lbl, L"Live preview");
-            draw_analog_clock(hdc, preview, p->analog_style, *s.theme, s.dpi, 10, 10, 30);
-        }
-
-    } else if (p->active_tab == TAB_TIMERS) {
-        RECT lbl = map_dlu(dlg, 70, 28, 100, 12);
-        lbl.top += sdy; lbl.bottom += sdy;
-        s.draw_label(hdc, lbl, L"Custom presets");
-
-        for (int i = 0; i < 5; ++i) {
-            RECT num = map_dlu(dlg, 76, (short)(40 + i * 16), 16, 12);
-            num.top += sdy; num.bottom += sdy;
-            auto txt = std::format(L"{}.", i + 1);
-            s.draw_label(hdc, num, txt.c_str());
-        }
+    switch (p->active_tab) {
+    case TAB_APPEARANCE: paint_appearance_tab(dlg, hdc, *p, sdy); break;
+    case TAB_CLOCK:      paint_clock_tab(dlg, hdc, *p, sdy);      break;
+    case TAB_TIMERS:     paint_timers_tab(dlg, hdc, *p, sdy);     break;
     }
 
     RestoreDC(hdc, save_dc);

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -248,6 +248,11 @@ static INT_PTR on_init(HWND dlg, LPARAM lp) {
     p->rects = compute_rects(dlg);
     p->clock_combo_rc = map_dlu(dlg, 68, 40, 212, 80);
 
+    p->brush_bg    = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+    p->brush_edit  = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+    p->brush_btn   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+    p->brush_combo = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+
     tab_appearance_init(dlg, *p);
     tab_pomodoro_init(dlg, *p);
     tab_timers_init(dlg, *p);
@@ -412,39 +417,23 @@ static INT_PTR on_ctl_color(HWND dlg, UINT msg, HDC hdc) {
     if (!p) return FALSE;
 
     switch (msg) {
-    case WM_CTLCOLORSTATIC: {
+    case WM_CTLCOLORSTATIC:
         SetTextColor(hdc, p->style.theme->text);
         SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
-    }
-    case WM_CTLCOLOREDIT: {
+        return (INT_PTR)p->brush_bg.h;
+    case WM_CTLCOLOREDIT:
         SetTextColor(hdc, p->style.theme->text);
         SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
-    }
-    case WM_CTLCOLORBTN: {
+        return (INT_PTR)p->brush_edit.h;
+    case WM_CTLCOLORBTN:
         SetTextColor(hdc, p->style.theme->text);
         SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
-    }
+        return (INT_PTR)p->brush_btn.h;
     case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORCOMBOBOX: {
+    case WM_CTLCOLORCOMBOBOX:
         SetTextColor(hdc, p->style.theme->text);
         SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_combo_bg = nullptr;
-        if (s_combo_bg) DeleteObject(s_combo_bg);
-        s_combo_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_combo_bg;
-    }
+        return (INT_PTR)p->brush_combo.h;
     }
     return FALSE;
 }

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -57,8 +57,8 @@ struct Params {
     HitRects rects{};
     int scroll_y = 0;       // current scroll offset in pixels
     RECT clock_combo_rc{};  // base pixel rect of the combobox (unscrolled)
-    GdiObj brush_bg;
-    GdiObj brush_edit;
-    GdiObj brush_btn;
-    GdiObj brush_combo;
+    GdiObj brush_bg{};
+    GdiObj brush_edit{};
+    GdiObj brush_btn{};
+    GdiObj brush_combo{};
 };

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -57,4 +57,8 @@ struct Params {
     HitRects rects{};
     int scroll_y = 0;       // current scroll offset in pixels
     RECT clock_combo_rc{};  // base pixel rect of the combobox (unscrolled)
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
+    GdiObj brush_combo;
 };


### PR DESCRIPTION
## Summary

Four independent, provably correct improvements identified from a full complexity + jump-cost review of the codebase.

- **Fix static HBRUSH leaks in all dialogs** — static brush locals in `WM_CTLCOLOR` handlers survived dialog close, leaking the last brush each time. Move ownership into `Params` as `GdiObj` fields, created once in `WM_INITDIALOG`, freed automatically when `Params` goes out of scope. Zero statics, fewer GDI allocations per paint cycle.
- **Extract `reset_timer_slot` helper** — the 8-line pomodoro/timer reset sequence existed verbatim in both `A_TMR_RST_ALL` and `A_TMR_RST`. One function, one place to change.
- **Extract `dispatch_timer_action` from `dispatch_action`** — the 70-line `A_TMR_BASE` default branch is now a standalone function. `dispatch_action` is a clean router; `actions.hpp` is imported by 5 modules and was the highest jump-cost file in the codebase.
- **Consolidate `DlgBuf`/`dlg_add_item` into `dialog_style.hpp`** — two identical `Buf` structs and near-identical `add_item` functions were duplicated across `alarm_dlg` and `pomo_dlg_detail`. Single shared implementation, any future dialog gets it for free.

## Test plan

- [ ] Build on Windows and verify alarm dialog opens/closes cleanly (no GDI leak on repeated open)
- [ ] Verify pomodoro dialog opens/closes cleanly
- [ ] Verify timer add/delete/start/reset/pomo/skip all behave correctly
- [ ] Verify `A_TMR_RST_ALL` resets all timers including pomodoro state
- [ ] Settings dialog opens, all tabs functional, theme brushes correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized timer actions and reset behavior into shared helpers.
  * Simplified keyboard start handling to remove duplicated logic.
  * Consolidated mouse timer preset/duration handling and persistence.
  * Centralized dialog template construction and control creation.
  * Moved dialog brush creation to per-dialog state (persistent brushes) for settings, alarm, and pomodoro dialogs.
  * Cleaned up painting/layout variables for timers and alarms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/351)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->