### PR TITLE
fix: eliminate HBRUSH leaks, extract timer helpers, unify dialog template builder

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -130,6 +130,77 @@ struct HandleResult {
     bool open_alarm_dialog = false;
 };
 
+inline HandleResult dispatch_timer_action(App& app, int idx, int off,
+                                           std::chrono::steady_clock::time_point now) {
+    using namespace std::chrono;
+    HandleResult r;
+    if (idx < 0 || idx >= (int)app.timers.size()) return r;
+    auto& ts = app.timers[idx];
+
+    if (off == A_TMR_START) {
+        if (!ts.t.touched()) {
+            if (ts.dur.count() > 0) ts.t.start(now);
+        } else if (ts.t.is_running())
+            ts.t.pause(now);
+        else
+            ts.t.start(now);
+    } else if (off == A_TMR_RST) {
+        reset_timer_slot(ts, app);
+    } else if (off == A_TMR_ADD) {
+        if ((int)app.timers.size() < Config::MAX_TIMERS) {
+            TimerSlot ns;
+            ns.t.set(ns.dur);
+            app.timers.insert(app.timers.begin() + idx + 1, ns);
+            r.resize = true;
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_DEL) {
+        if ((int)app.timers.size() > 1) {
+            app.timers.erase(app.timers.begin() + idx);
+            r.resize = true;
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_POMO) {
+        if (!ts.t.touched()) {
+            if (ts.pomodoro) {
+                ts.pomodoro = false;
+                ts.label.clear();
+            } else {
+                ts.pomodoro = true;
+                ts.pomodoro_phase = 0;
+                ts.pomodoro_work_elapsed = {};
+                ts.dur = seconds{app.pomodoro_work_secs};
+                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
+                ts.notified = false;
+                ts.t.reset();
+                ts.t.set(ts.dur);
+            }
+            r.save_config = true;
+        }
+    } else if (off == A_TMR_SKIP) {
+        if (ts.pomodoro && ts.t.touched()) {
+            if (pomodoro_is_work(ts.pomodoro_phase)) {
+                auto elapsed = duration_cast<seconds>(ts.t.total_elapsed(now));
+                ts.pomodoro_work_elapsed += elapsed;
+            }
+            ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, app.pomodoro_cadence);
+            auto secs = seconds{pomodoro_phase_secs(ts.pomodoro_phase,
+                app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs,
+                app.pomodoro_cadence)};
+            ts.dur = secs;
+            ts.notified = false;
+            ts.t.reset();
+            ts.t.set(secs);
+            ts.t.start(now);
+            ts.label = pomodoro_phase_label(ts.pomodoro_phase, app.pomodoro_cadence);
+            r.save_config = true;
+        }
+    } else if (!ts.t.touched() && apply_timer_hms_adjust(ts, off)) {
+        r.save_config = true;
+    }
+    return r;
+}
+
 inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock::time_point now,
                                      const std::filesystem::path& config_dir) {
     using namespace std::chrono;
@@ -251,69 +322,7 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         } else if (act >= A_TMR_BASE) {
             int idx = (act - A_TMR_BASE) / TMR_STRIDE;
             int off = (act - A_TMR_BASE) % TMR_STRIDE;
-            if (idx < 0 || idx >= (int)app.timers.size()) break;
-            auto& ts = app.timers[idx];
-            if (off == A_TMR_START) {
-                if (!ts.t.touched()) {
-                    if (ts.dur.count() > 0) ts.t.start(now);
-                } else if (ts.t.is_running())
-                    ts.t.pause(now);
-                else
-                    ts.t.start(now);
-            } else if (off == A_TMR_RST) {
-                reset_timer_slot(ts, app);
-            } else if (off == A_TMR_ADD) {
-                if ((int)app.timers.size() < Config::MAX_TIMERS) {
-                    TimerSlot ns;
-                    ns.t.set(ns.dur);
-                    app.timers.insert(app.timers.begin() + idx + 1, ns);
-                    r.resize = true;
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_DEL) {
-                if ((int)app.timers.size() > 1) {
-                    app.timers.erase(app.timers.begin() + idx);
-                    r.resize = true;
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_POMO) {
-                if (!ts.t.touched()) {
-                    if (ts.pomodoro) {
-                        ts.pomodoro = false;
-                        ts.label.clear();
-                    } else {
-                        ts.pomodoro = true;
-                        ts.pomodoro_phase = 0;
-                        ts.pomodoro_work_elapsed = {};
-                        ts.dur = seconds{app.pomodoro_work_secs};
-                        ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                        ts.notified = false;
-                        ts.t.reset();
-                        ts.t.set(ts.dur);
-                    }
-                    r.save_config = true;
-                }
-            } else if (off == A_TMR_SKIP) {
-                if (ts.pomodoro && ts.t.touched()) {
-                    if (pomodoro_is_work(ts.pomodoro_phase)) {
-                        auto elapsed = duration_cast<seconds>(ts.t.total_elapsed(now));
-                        ts.pomodoro_work_elapsed += elapsed;
-                    }
-                    ts.pomodoro_phase = pomodoro_next_phase(ts.pomodoro_phase, app.pomodoro_cadence);
-                    auto secs = seconds{pomodoro_phase_secs(ts.pomodoro_phase,
-                        app.pomodoro_work_secs, app.pomodoro_short_secs, app.pomodoro_long_secs,
-                        app.pomodoro_cadence)};
-                    ts.dur = secs;
-                    ts.notified = false;
-                    ts.t.reset();
-                    ts.t.set(secs);
-                    ts.t.start(now);
-                    ts.label = pomodoro_phase_label(ts.pomodoro_phase, app.pomodoro_cadence);
-                    r.save_config = true;
-                }
-            } else if (!ts.t.touched() && apply_timer_hms_adjust(ts, off)) {
-                r.save_config = true;
-            }
+            r = dispatch_timer_action(app, idx, off, now);
         }
     }
     return r;

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -170,13 +170,7 @@ inline HandleResult dispatch_timer_action(App& app, int idx, int off,
                 ts.label.clear();
             } else {
                 ts.pomodoro = true;
-                ts.pomodoro_phase = 0;
-                ts.pomodoro_work_elapsed = {};
-                ts.dur = seconds{app.pomodoro_work_secs};
-                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                ts.notified = false;
-                ts.t.reset();
-                ts.t.set(ts.dur);
+                reset_timer_slot(ts, app);
             }
             r.save_config = true;
         }

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -47,6 +47,18 @@ constexpr int A_TMR_DEL = 9;
 constexpr int A_TMR_POMO = 10;
 constexpr int A_TMR_SKIP = 11;
 
+inline void reset_timer_slot(TimerSlot& ts, const App& app) {
+    ts.notified = false;
+    if (ts.pomodoro) {
+        ts.pomodoro_phase = 0;
+        ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
+        ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
+        ts.pomodoro_work_elapsed = {};
+    }
+    ts.t.reset();
+    ts.t.set(ts.dur);
+}
+
 inline bool apply_timer_hms_adjust(TimerSlot& ts, int off) {
     auto total = ts.dur.count();
     int h = (int)(total / 3600);
@@ -218,17 +230,8 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
         r.open_alarm_dialog = true;
         break;
     case A_TMR_RST_ALL:
-        for (auto& ts : app.timers) {
-            ts.notified = false;
-            if (ts.pomodoro) {
-                ts.pomodoro_phase = 0;
-                ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
-                ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                ts.pomodoro_work_elapsed = {};
-            }
-            ts.t.reset();
-            ts.t.set(ts.dur);
-        }
+        for (auto& ts : app.timers)
+            reset_timer_slot(ts, app);
         r.save_config = true;
         break;
     default:
@@ -258,15 +261,7 @@ inline HandleResult dispatch_action(App& app, int act, std::chrono::steady_clock
                 else
                     ts.t.start(now);
             } else if (off == A_TMR_RST) {
-                ts.notified = false;
-                if (ts.pomodoro) {
-                    ts.pomodoro_phase = 0;
-                    ts.dur = std::chrono::seconds{app.pomodoro_work_secs};
-                    ts.label = pomodoro_phase_label(0, app.pomodoro_cadence);
-                    ts.pomodoro_work_elapsed = {};
-                }
-                ts.t.reset();
-                ts.t.set(ts.dur);
+                reset_timer_slot(ts, app);
             } else if (off == A_TMR_ADD) {
                 if ((int)app.timers.size() < Config::MAX_TIMERS) {
                     TimerSlot ns;

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -148,6 +148,7 @@ inline HandleResult dispatch_timer_action(App& app, int idx, int off,
             ts.t.start(now);
     } else if (off == A_TMR_RST) {
         reset_timer_slot(ts, app);
+        r.save_config = true;
     } else if (off == A_TMR_ADD) {
         if ((int)app.timers.size() < Config::MAX_TIMERS) {
             TimerSlot ns;

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -47,6 +47,7 @@ constexpr int A_TMR_DEL = 9;
 constexpr int A_TMR_POMO = 10;
 constexpr int A_TMR_SKIP = 11;
 
+/// Resets @p ts to its initial state, restoring pomodoro phase 0 if applicable.
 inline void reset_timer_slot(TimerSlot& ts, const App& app) {
     ts.notified = false;
     if (ts.pomodoro) {
@@ -130,6 +131,7 @@ struct HandleResult {
     bool open_alarm_dialog = false;
 };
 
+/// Handles a single timer-slot action (start/stop, adjust, add/del, pomodoro).
 inline HandleResult dispatch_timer_action(App& app, int idx, int off,
                                            std::chrono::steady_clock::time_point now) {
     using namespace std::chrono;

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -44,30 +44,8 @@ struct Params {
 
 // ─── Template builder ─────────────────────────────────────────────────────────
 
-struct Buf {
-    std::vector<WORD> data;
-    void align4() { while (data.size() % 2) data.push_back(0); }
-    void push_word(WORD w)   { data.push_back(w); }
-    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
-    void push_wstr_empty() { data.push_back(0); }
-};
-
-inline void add_item(Buf& b, DWORD style, short x, short y, short cx, short cy,
-                     WORD id, WORD cls_atom, const wchar_t* title) {
-    b.align4();
-    b.push_dword(WS_CHILD | WS_VISIBLE | style);
-    b.push_dword(0); // exStyle
-    b.push_word((WORD)x); b.push_word((WORD)y);
-    b.push_word((WORD)cx); b.push_word((WORD)cy);
-    b.push_word(id);
-    b.push_word(0xFFFF); b.push_word(cls_atom);
-    b.push_wstr(title);
-    b.push_word(0);
-}
-
 inline std::vector<WORD> build_template() {
-    Buf b;
+    DlgBuf b;
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);
     b.push_word(CTRL_COUNT);
@@ -78,23 +56,23 @@ inline std::vector<WORD> build_template() {
     b.push_wstr_empty(); // caption (painted)
 
     // Name edit  (x=46 y=25 w=148 h=11)
-    add_item(b, ES_AUTOHSCROLL | WS_TABSTOP, 46, 25, 148, 11, IDC_ALM_NAME, CLS_EDIT, L"");
+    dlg_add_item(b, ES_AUTOHSCROLL | WS_TABSTOP, 46, 25, 148, 11, IDC_ALM_NAME, CLS_EDIT, L"");
     // Hour edit  (x=46 y=40 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 46, 40, 22, 11, IDC_ALM_HOUR, CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 46, 40, 22, 11, IDC_ALM_HOUR, CLS_EDIT, L"");
     // Min edit   (x=78 y=40 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 78, 40, 22, 11, IDC_ALM_MIN,  CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 78, 40, 22, 11, IDC_ALM_MIN,  CLS_EDIT, L"");
 
     // Date fields: Year (x=36 y=70 w=38 h=11), Month (x=104 y=70 w=22 h=11), Day (x=158 y=70 w=22 h=11)
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 36, 70, 38, 11, IDC_ALM_YEAR,  CLS_EDIT, L"");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 104, 70, 22, 11, IDC_ALM_MONTH, CLS_EDIT, L"");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 158, 70, 22, 11, IDC_ALM_DAY,   CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 36, 70, 38, 11, IDC_ALM_YEAR,  CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 104, 70, 22, 11, IDC_ALM_MONTH, CLS_EDIT, L"");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 158, 70, 22, 11, IDC_ALM_DAY,   CLS_EDIT, L"");
 
     // OK / Cancel (owner-draw)
     constexpr short btn_w = 44, btn_h = 16;
     constexpr short btn_y = 118;
     constexpr short btn_x0 = (DLG_W - 2 * btn_w - 8) / 2;
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0, btn_y, btn_w, btn_h, IDC_ALM_OK,     CLS_BUTTON, L"OK");
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0 + btn_w + 8, btn_y, btn_w, btn_h, IDC_ALM_CANCEL, CLS_BUTTON, L"Cancel");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0, btn_y, btn_w, btn_h, IDC_ALM_OK,     CLS_BUTTON, L"OK");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP, btn_x0 + btn_w + 8, btn_y, btn_w, btn_h, IDC_ALM_CANCEL, CLS_BUTTON, L"Cancel");
 
     return b.data;
 }

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -44,7 +44,7 @@ struct Params {
 
 // ─── Template builder ─────────────────────────────────────────────────────────
 
-inline std::vector<DWORD> build_template() {
+inline std::vector<WORD> build_template() {
     DlgBuf b;
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -44,7 +44,7 @@ struct Params {
 
 // ─── Template builder ─────────────────────────────────────────────────────────
 
-inline std::vector<WORD> build_template() {
+inline std::vector<DWORD> build_template() {
     DlgBuf b;
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -37,9 +37,9 @@ struct Params {
     RECT rc_days_btn{};
     RECT rc_date_btn{};
     RECT rc_day[7]{};  // Mon-Sun painted toggles
-    GdiObj brush_bg;
-    GdiObj brush_edit;
-    GdiObj brush_btn;
+    GdiObj brush_bg{};
+    GdiObj brush_edit{};
+    GdiObj brush_btn{};
 };
 
 // ─── Template builder ─────────────────────────────────────────────────────────

--- a/src/alarm_dialog.hpp
+++ b/src/alarm_dialog.hpp
@@ -37,6 +37,9 @@ struct Params {
     RECT rc_days_btn{};
     RECT rc_date_btn{};
     RECT rc_day[7]{};  // Mon-Sun painted toggles
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
 };
 
 // ─── Template builder ─────────────────────────────────────────────────────────
@@ -164,6 +167,9 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         }
 
         init_painted_rects(dlg, *p);
+        p->brush_bg   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+        p->brush_edit = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+        p->brush_btn  = GdiObj{CreateSolidBrush(p->style.theme->bg)};
 
         // Set fonts on all children
         EnumChildWindows(dlg, [](HWND ch, LPARAM par) -> BOOL {
@@ -253,30 +259,19 @@ inline INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
 
     case WM_CTLCOLORSTATIC: {
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkMode((HDC)wp, TRANSPARENT);
+        return (INT_PTR)p->brush_bg.h;
     }
     case WM_CTLCOLOREDIT: {
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkColor((HDC)wp, p->style.theme->bar);
+        return (INT_PTR)p->brush_edit.h;
     }
     case WM_CTLCOLORBTN: {
         if (!p) break;
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
+        return (INT_PTR)p->brush_btn.h;
     }
 
     case WM_NCHITTEST: {

--- a/src/dialog_style.hpp
+++ b/src/dialog_style.hpp
@@ -8,6 +8,7 @@
 
 // ─── Runtime DLGTEMPLATE builder ─────────────────────────────────────────────
 
+/// Word-stream buffer for building a DLGTEMPLATE at runtime.
 struct DlgBuf {
     std::vector<WORD> data;
     void align4() { while (data.size() % 2) data.push_back(0); }
@@ -17,6 +18,7 @@ struct DlgBuf {
     void push_wstr_empty() { data.push_back(0); }
 };
 
+/// Appends a DLGITEMTEMPLATE entry to @p b for a standard Win32 control class atom.
 inline void dlg_add_item(DlgBuf& b, DWORD style, short x, short y, short cx, short cy,
                           WORD id, WORD cls_atom, const wchar_t* title) {
     b.align4();

--- a/src/dialog_style.hpp
+++ b/src/dialog_style.hpp
@@ -1,9 +1,34 @@
 #pragma once
+#include <vector>
 #include <windows.h>
 #include "dwm_fwd.hpp"
 #include "gdi.hpp"
 #include "layout.hpp"
 #include "theme.hpp"
+
+// ─── Runtime DLGTEMPLATE builder ─────────────────────────────────────────────
+
+struct DlgBuf {
+    std::vector<WORD> data;
+    void align4() { while (data.size() % 2) data.push_back(0); }
+    void push_word(WORD w)   { data.push_back(w); }
+    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
+    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
+    void push_wstr_empty() { data.push_back(0); }
+};
+
+inline void dlg_add_item(DlgBuf& b, DWORD style, short x, short y, short cx, short cy,
+                          WORD id, WORD cls_atom, const wchar_t* title) {
+    b.align4();
+    b.push_dword(WS_CHILD | WS_VISIBLE | style);
+    b.push_dword(0);
+    b.push_word((WORD)x); b.push_word((WORD)y);
+    b.push_word((WORD)cx); b.push_word((WORD)cy);
+    b.push_word(id);
+    b.push_word(0xFFFF); b.push_word(cls_atom);
+    b.push_wstr(title);
+    b.push_word(0);
+}
 
 // Reusable owner-drawn dialog styling for Chronos dialogs.
 // Ensures popups share the same visual language as the main window.

--- a/src/dialog_style.hpp
+++ b/src/dialog_style.hpp
@@ -9,13 +9,21 @@
 // ─── Runtime DLGTEMPLATE builder ─────────────────────────────────────────────
 
 /// Word-stream buffer for building a DLGTEMPLATE at runtime.
+/// Backed by DWORD elements to guarantee the 4-byte alignment required by DLGTEMPLATE.
 struct DlgBuf {
-    std::vector<WORD> data;
-    void align4() { while (data.size() % 2) data.push_back(0); }
-    void push_word(WORD w)   { data.push_back(w); }
-    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
-    void push_wstr_empty() { data.push_back(0); }
+    std::vector<DWORD> data;
+    size_t nbytes = 0;
+
+    void _byte(BYTE b) {
+        if (nbytes % 4 == 0) data.push_back(0);
+        reinterpret_cast<BYTE*>(data.data())[nbytes] = b;
+        ++nbytes;
+    }
+    void align4()            { while (nbytes % 4) _byte(0); }
+    void push_word(WORD w)   { _byte(LOBYTE(w)); _byte(HIBYTE(w)); }
+    void push_dword(DWORD d) { push_word(LOWORD(d)); push_word(HIWORD(d)); }
+    void push_wstr(const wchar_t* s) { while (*s) push_word((WORD)*s++); push_word(0); }
+    void push_wstr_empty()   { push_word(0); }
 };
 
 /// Appends a DLGITEMTEMPLATE entry to @p b for a standard Win32 control class atom.

--- a/src/dialog_style.hpp
+++ b/src/dialog_style.hpp
@@ -9,21 +9,13 @@
 // ─── Runtime DLGTEMPLATE builder ─────────────────────────────────────────────
 
 /// Word-stream buffer for building a DLGTEMPLATE at runtime.
-/// Backed by DWORD elements to guarantee the 4-byte alignment required by DLGTEMPLATE.
 struct DlgBuf {
-    std::vector<DWORD> data;
-    size_t nbytes = 0;
-
-    void _byte(BYTE b) {
-        if (nbytes % 4 == 0) data.push_back(0);
-        reinterpret_cast<BYTE*>(data.data())[nbytes] = b;
-        ++nbytes;
-    }
-    void align4()            { while (nbytes % 4) _byte(0); }
-    void push_word(WORD w)   { _byte(LOBYTE(w)); _byte(HIBYTE(w)); }
-    void push_dword(DWORD d) { push_word(LOWORD(d)); push_word(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) push_word((WORD)*s++); push_word(0); }
-    void push_wstr_empty()   { push_word(0); }
+    std::vector<WORD> data;
+    void align4()            { while (data.size() % 2) data.push_back(0); }
+    void push_word(WORD w)   { data.push_back(w); }
+    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
+    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
+    void push_wstr_empty()   { data.push_back(0); }
 };
 
 /// Appends a DLGITEMTEMPLATE entry to @p b for a standard Win32 control class atom.

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -115,6 +115,9 @@ inline std::vector<WORD> build_template() {
 struct Params {
     int work_min, short_min, long_min;
     DlgStyle style;
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
 };
 
 inline bool read_field(HWND dlg, int id, int& out) {
@@ -159,6 +162,10 @@ inline INT_PTR CALLBACK PomoDlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             return TRUE;
         }, (LPARAM)p);
 
+        p->brush_bg   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+        p->brush_edit = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+        p->brush_btn  = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+
         SetFocus(GetDlgItem(dlg, IDC_POMO_WORK));
         SendDlgItemMessageW(dlg, IDC_POMO_WORK, EM_SETSEL, 0, -1);
         return FALSE;
@@ -193,32 +200,21 @@ inline INT_PTR CALLBACK PomoDlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_CTLCOLORSTATIC: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkMode((HDC)wp, TRANSPARENT);
+        return (INT_PTR)p->brush_bg.h;
     }
     case WM_CTLCOLOREDIT: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        HDC hdc = (HDC)wp;
-        SetTextColor(hdc, p->style.theme->text);
-        SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
+        SetTextColor((HDC)wp, p->style.theme->text);
+        SetBkColor((HDC)wp, p->style.theme->bar);
+        return (INT_PTR)p->brush_edit.h;
     }
     case WM_CTLCOLORBTN: {
         auto* p = reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
         if (!p) break;
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
+        return (INT_PTR)p->brush_btn.h;
     }
     case WM_NCHITTEST: {
         RECT title_rc = {0, 0, DLG_W, 22};

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -2,7 +2,6 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <format>
-#include <vector>
 #include "app.hpp"
 #include "dialog_style.hpp"
 
@@ -22,35 +21,12 @@ constexpr WORD CLS_BUTTON = 0x0080;
 constexpr WORD CLS_EDIT   = 0x0081;
 constexpr WORD CLS_STATIC = 0x0082;
 
-struct Buf {
-    std::vector<WORD> data;
-    void align4() { while (data.size() % 2) data.push_back(0); }
-    void push_word(WORD w)  { data.push_back(w); }
-    void push_dword(DWORD d) { data.push_back(LOWORD(d)); data.push_back(HIWORD(d)); }
-    void push_wstr(const wchar_t* s) { while (*s) data.push_back((WORD)*s++); data.push_back(0); }
-    void push_wstr_empty() { data.push_back(0); }
-};
-
-inline void add_item(Buf& b, DWORD style, DWORD exStyle,
-                     short x, short y, short cx, short cy,
-                     WORD id, WORD cls_atom, const wchar_t* title) {
-    b.align4();
-    b.push_dword(WS_CHILD | WS_VISIBLE | style);
-    b.push_dword(exStyle);
-    b.push_word((WORD)x);  b.push_word((WORD)y);
-    b.push_word((WORD)cx); b.push_word((WORD)cy);
-    b.push_word(id);
-    b.push_word(0xFFFF); b.push_word(cls_atom);
-    b.push_wstr(title);
-    b.push_word(0);
-}
-
 // 3 labels + 3 edits + 3 "min" statics + 2 buttons = 11
 constexpr WORD DLG_ITEM_COUNT = 11;
 constexpr short DLG_W = 170, DLG_H = 110;
 
 inline std::vector<WORD> build_template() {
-    Buf b;
+    DlgBuf b;
 
     b.push_dword(WS_POPUP | WS_BORDER);
     b.push_dword(0);
@@ -72,40 +48,40 @@ inline std::vector<WORD> build_template() {
     short row_h = 12;
 
     // Row 0 — Work
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, row_y0, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Work");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, row_y0, ed_w, row_h, IDC_POMO_WORK, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, row_y0, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, row_y0, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Work");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, row_y0, ed_w, row_h, IDC_POMO_WORK, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, row_y0, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Row 1 — Short break
     short r1 = row_y0 + row_sp;
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, r1, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Short break");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, r1, ed_w, row_h, IDC_POMO_SHORT, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, r1, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, r1, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Short break");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, r1, ed_w, row_h, IDC_POMO_SHORT, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, r1, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Row 2 — Long break
     short r2 = row_y0 + 2 * row_sp;
-    add_item(b, SS_RIGHT | SS_CENTERIMAGE, 0,
-             lbl_x, r2, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Long break");
-    add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP, 0,
-             ed_x, r2, ed_w, row_h, IDC_POMO_LONG, CLS_EDIT, L"");
-    add_item(b, SS_LEFT | SS_CENTERIMAGE, 0,
-             min_x, r2, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
+    dlg_add_item(b, SS_RIGHT | SS_CENTERIMAGE,
+                 lbl_x, r2, lbl_w, row_h, 0xFFFF, CLS_STATIC, L"Long break");
+    dlg_add_item(b, ES_NUMBER | ES_CENTER | WS_TABSTOP,
+                 ed_x, r2, ed_w, row_h, IDC_POMO_LONG, CLS_EDIT, L"");
+    dlg_add_item(b, SS_LEFT | SS_CENTERIMAGE,
+                 min_x, r2, min_w, row_h, 0xFFFF, CLS_STATIC, L"min");
 
     // Buttons — centered at bottom
     short btn_y = row_y0 + 3 * row_sp + 4;
     short btn_w = 44, btn_h = 16, btn_gap = 8;
     short total_w = 2 * btn_w + btn_gap;
     short btn_x0 = (DLG_W - total_w) / 2;
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
-             btn_x0, btn_y, btn_w, btn_h, IDC_BTN_OK, CLS_BUTTON, L"OK");
-    add_item(b, BS_OWNERDRAW | WS_TABSTOP, 0,
-             btn_x0 + btn_w + btn_gap, btn_y, btn_w, btn_h, IDC_BTN_CANCEL, CLS_BUTTON, L"Cancel");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP,
+                 btn_x0, btn_y, btn_w, btn_h, IDC_BTN_OK, CLS_BUTTON, L"OK");
+    dlg_add_item(b, BS_OWNERDRAW | WS_TABSTOP,
+                 btn_x0 + btn_w + btn_gap, btn_y, btn_w, btn_h, IDC_BTN_CANCEL, CLS_BUTTON, L"Cancel");
 
     return b.data;
 }

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -25,7 +25,7 @@ constexpr WORD CLS_STATIC = 0x0082;
 constexpr WORD DLG_ITEM_COUNT = 11;
 constexpr short DLG_W = 170, DLG_H = 110;
 
-inline std::vector<DWORD> build_template() {
+inline std::vector<WORD> build_template() {
     DlgBuf b;
 
     b.push_dword(WS_POPUP | WS_BORDER);

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -91,9 +91,9 @@ inline std::vector<WORD> build_template() {
 struct Params {
     int work_min, short_min, long_min;
     DlgStyle style;
-    GdiObj brush_bg;
-    GdiObj brush_edit;
-    GdiObj brush_btn;
+    GdiObj brush_bg{};
+    GdiObj brush_edit{};
+    GdiObj brush_btn{};
 };
 
 inline bool read_field(HWND dlg, int id, int& out) {

--- a/src/pomodoro_dialog.hpp
+++ b/src/pomodoro_dialog.hpp
@@ -25,7 +25,7 @@ constexpr WORD CLS_STATIC = 0x0082;
 constexpr WORD DLG_ITEM_COUNT = 11;
 constexpr short DLG_W = 170, DLG_H = 110;
 
-inline std::vector<WORD> build_template() {
+inline std::vector<DWORD> build_template() {
     DlgBuf b;
 
     b.push_dword(WS_POPUP | WS_BORDER);

--- a/src/ui_windows_settings_dialog_handlers.hpp
+++ b/src/ui_windows_settings_dialog_handlers.hpp
@@ -248,6 +248,11 @@ static INT_PTR on_init(HWND dlg, LPARAM lp) {
     p->rects = compute_rects(dlg);
     p->clock_combo_rc = map_dlu(dlg, 68, 40, 212, 80);
 
+    p->brush_bg    = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+    p->brush_edit  = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+    p->brush_btn   = GdiObj{CreateSolidBrush(p->style.theme->bg)};
+    p->brush_combo = GdiObj{CreateSolidBrush(p->style.theme->bar)};
+
     tab_appearance_init(dlg, *p);
     tab_pomodoro_init(dlg, *p);
     tab_timers_init(dlg, *p);
@@ -404,39 +409,23 @@ static INT_PTR on_ctl_color(HWND dlg, UINT msg, HDC hdc) {
     if (!p) return FALSE;
 
     switch (msg) {
-    case WM_CTLCOLORSTATIC: {
+    case WM_CTLCOLORSTATIC:
         SetTextColor(hdc, p->style.theme->text);
         SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_bg = nullptr;
-        if (s_bg) DeleteObject(s_bg);
-        s_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_bg;
-    }
-    case WM_CTLCOLOREDIT: {
+        return (INT_PTR)p->brush_bg.h;
+    case WM_CTLCOLOREDIT:
         SetTextColor(hdc, p->style.theme->text);
         SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_edit_bg = nullptr;
-        if (s_edit_bg) DeleteObject(s_edit_bg);
-        s_edit_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_edit_bg;
-    }
-    case WM_CTLCOLORBTN: {
+        return (INT_PTR)p->brush_edit.h;
+    case WM_CTLCOLORBTN:
         SetTextColor(hdc, p->style.theme->text);
         SetBkMode(hdc, TRANSPARENT);
-        static HBRUSH s_btn_bg = nullptr;
-        if (s_btn_bg) DeleteObject(s_btn_bg);
-        s_btn_bg = CreateSolidBrush(p->style.theme->bg);
-        return (INT_PTR)s_btn_bg;
-    }
+        return (INT_PTR)p->brush_btn.h;
     case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORCOMBOBOX: {
+    case WM_CTLCOLORCOMBOBOX:
         SetTextColor(hdc, p->style.theme->text);
         SetBkColor(hdc, p->style.theme->bar);
-        static HBRUSH s_combo_bg = nullptr;
-        if (s_combo_bg) DeleteObject(s_combo_bg);
-        s_combo_bg = CreateSolidBrush(p->style.theme->bar);
-        return (INT_PTR)s_combo_bg;
-    }
+        return (INT_PTR)p->brush_combo.h;
     }
     return FALSE;
 }

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -57,8 +57,8 @@ struct Params {
     HitRects rects{};
     int scroll_y = 0;       // current scroll offset in pixels
     RECT clock_combo_rc{};  // base pixel rect of the combobox (unscrolled)
-    GdiObj brush_bg;
-    GdiObj brush_edit;
-    GdiObj brush_btn;
-    GdiObj brush_combo;
+    GdiObj brush_bg{};
+    GdiObj brush_edit{};
+    GdiObj brush_btn{};
+    GdiObj brush_combo{};
 };

--- a/src/ui_windows_settings_dialog_state.hpp
+++ b/src/ui_windows_settings_dialog_state.hpp
@@ -57,4 +57,8 @@ struct Params {
     HitRects rects{};
     int scroll_y = 0;       // current scroll offset in pixels
     RECT clock_combo_rc{};  // base pixel rect of the combobox (unscrolled)
+    GdiObj brush_bg;
+    GdiObj brush_edit;
+    GdiObj brush_btn;
+    GdiObj brush_combo;
 };


### PR DESCRIPTION
## Summary
- Replace per-repaint static HBRUSH locals in all dialog WM_CTLCOLOR handlers with brushes stored on `Params` structs (created once in WM_INITDIALOG, freed by RAII), eliminating GDI leaks
- Extract `reset_timer_slot` and `dispatch_timer_action` from `dispatch_action`; reuse `reset_timer_slot` in the pomodoro-enable branch to eliminate duplicate reset logic
- Fix missing `r.save_config = true` on single-slot timer reset (`A_TMR_RST`)
- Consolidate duplicate `Buf`/`add_item` template-builder code from `alarm_dialog.hpp` and `pomodoro_dialog.hpp` into shared `DlgBuf`/`dlg_add_item` in `dialog_style.hpp`
- Add `{}` default member initializers to all `GdiObj` brush fields in `Params` structs to satisfy `-Wmissing-designated-field-initializers`
- Add `///` docstrings to newly introduced public functions

## Test plan
- [x] All CI checks pass (build-and-test, coverage, sanitizer-check, test-linux, test-linux-debug)
- [x] Timer single-slot reset correctly triggers a config save
- [x] Pomodoro enable path initializes all fields via `reset_timer_slot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced rendering stability and visual consistency across alarm, pomodoro, and settings dialogs through improved internal resource management.
  * Consolidated timer-slot action handling for increased reliability and better performance in multi-slot timer operations.
  * Improved dialog template construction system for more robust and maintainable dialog building.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/362)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->