### PR TITLE
fix: make Justfile use PATH-based toolchain by default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
-cmake := "C:/msys64/mingw64/bin/cmake.exe"
-cxx   := "C:/msys64/mingw64/bin/clang++.exe"
+cmake := env("CMAKE", "cmake")
+cxx   := env("CXX", "clang++")
 
 build:
     {{cmake}} --preset release -DCMAKE_CXX_COMPILER={{cxx}}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ just build
 just run
 ```
 
+The Justfile picks up `cmake` and `clang++` from `PATH` by default. Override via environment variables if your toolchain lives elsewhere:
+
+```
+CMAKE=C:/msys64/mingw64/bin/cmake.exe CXX=C:/msys64/mingw64/bin/clang++.exe just build
+```
+
 Or directly with CMake (using [presets](CMakePresets.json)):
 
 ```


### PR DESCRIPTION
## Summary

- `Justfile` previously hardcoded `C:/msys64/mingw64/bin/cmake.exe` and `C:/msys64/mingw64/bin/clang++.exe`, so `just build` failed immediately for anyone whose MSYS2 isn't at that exact path
- Both variables now read from environment (`CMAKE`, `CXX`) and fall back to bare `cmake` / `clang++` — consistent with how `CMakePresets.json` already works
- README documents the override pattern for users with non-standard toolchain locations

## Test plan

- [ ] `just build` works on a standard MSYS2 MINGW64 setup where `cmake` and `clang++` are on `PATH`
- [ ] `CMAKE=... CXX=... just build` still works for users with non-standard paths
- [ ] CI is unaffected (CI doesn't use the Justfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to support environment variable overrides for build tool selection, allowing flexible toolchain customization.

* **Documentation**
  * Expanded build instructions with guidance on configuring and overriding toolchain paths using environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/365)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->