### PR TITLE
Introduce platform‑neutral UI style/scene and refactor Windows/Linux painters; split core CMake targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,6 +95,8 @@ block-beta
         layoutHpp["layout.hpp"]
         geometryHpp["geometry.hpp"]
         wndstateHpp["wndstate.hpp"]
+        uiStyleHpp["ui_style.hpp"]
+        uiSceneHpp["ui_scene.hpp"]
         themeHpp["theme.hpp"]
         trayHpp["tray.hpp"]
         iconHpp["icon.hpp"]
@@ -109,6 +111,25 @@ block-beta
     end
 ```
 
+
+## UI Surface Inventory
+
+The Windows UI currently creates and paints these surfaces. The long-term painter split should keep the left column as platform-neutral config/recipes and let Win32/GDI or Linux/X11 provide only the final adapter:
+
+| Surface | Current Windows ownership | Platform-neutral direction |
+|---------|---------------------------|----------------------------|
+| App shell/window | `ui_windows_app.cpp`, `window.cpp`, `wndstate.hpp` | Window host and event pump stay platform-specific; app state, layout intent, and style selection stay shared. |
+| Surfaces/panels | Main background, bar, help overlay, dialog body | `UiMakers::surface` / `dialog` describe fills and borders; adapters only fill rectangles/native windows. |
+| Text/labels/readouts | Clock, stopwatch, timer fields, subtitles, empty states | `UiMakers::text` maps semantic tones (`Primary`, `Dim`, `Warning`, `Danger`) to colors; adapters own fonts and text APIs. |
+| Dividers/separators | Section dividers and dialog title rules | `UiMakers::divider` provides the rule color; adapters draw the line primitive. |
+| Buttons/toggles/chips | Toolbar buttons, timer controls, alarm day chips, settings options | `UiMakers::button` / `toggle` return `WidgetPaint`; platform adapters draw GDI/X11 primitives. |
+| Dropdowns/combos | Win32 combo boxes in settings dialog | `UiMakers::dropdown` defines shared colors/radius; platform code owns native control creation. |
+| Progress/meters | Countdown fill bars and expired fills | `UiMakers::progress` chooses semantic fill color; adapters fill the computed geometry. |
+| Dialogs | `dialog_style.*`, `alarm_dialog.cpp`, `pomodoro_dialog.cpp`, settings dialog | `UiMakers::dialog` provides title/background/divider styling; platform code owns modal loops and native child controls. |
+| Scrollable views | Settings dialog scroll state and painted analog options | `UiMakers::scroll_view` provides track/thumb/divider styling; platform code owns wheel/scrollbar integration. |
+| Analog clock | `painting_analog.*` | `UiMakers::analog_clock` centralizes semantic colors; platform painters draw lines, ticks, labels, and dots. |
+| Icons/tray | `icon.hpp`, `tray.hpp` | `UiMakers::icon` describes semantic icon colors; platform code produces `HICON`, tray notifications, or Linux equivalents. |
+
 ## Key Data Structures
 
 **`App`** (`app.hpp`) -- Central application state. Holds the stopwatch, a vector of `TimerSlot`s (each pairing a `Timer` with its duration, label, notification flag, and pomodoro state), visibility toggles, and theme mode. This is the only mutable state that the action layer touches.
@@ -121,9 +142,17 @@ block-beta
 
 **`Layout`** (`layout.hpp`) -- DPI-scaled dimensions for every UI element. All sizes are defined as base constants at 96 DPI and scaled proportionally via `dpi_scale()`. Updated on `WM_DPICHANGED`.
 
+**`ui_style.hpp`** -- Platform-neutral color palettes and a grouped `UiMakers` recipe object. New widgets should be assembled from the existing makers (surface, text, divider, button/toggle/dropdown, progress, dialog, scroll view, analog clock, icon) before adding a new primitive. Windows converts these colors to `COLORREF` in `theme.hpp`; Linux/X11 converts the same palette to X11 pixels.
+
+**`ui_scene.hpp`** -- Platform-neutral scene operations for the shared main app surface. The Linux backend renders this scene directly through X11, and it gives the Windows painter a concrete target for future migration away from hand-painted per-module drawing.
+
 ## Design Decisions
 
 **Multi-translation-unit build** -- Each logical module has a `.hpp` (declarations) and a `.cpp` (definitions), compiled in parallel. `main.cpp` is the entry point; platform-specific sources (`ui_windows_app.cpp`, `ui_linux.cpp`, dialogs) are gated by CMake platform conditions.
+
+**Shared core target** -- CMake builds the logic-portable files (`actions`, config serialization, encoding, formatting) once as `chronos_core`. The desktop app and unit tests both link that target, so adding a portable source usually means editing one source list instead of keeping app and test lists in sync. Common warning flags and optional LLD wiring live in reusable CMake helpers rather than being repeated per target.
+
+**Platform-neutral style decisions** -- Theme palettes and widget recipes are represented without Win32 or X11 types in `ui_style.hpp`. Platform code owns only the final rendering adapter: Win32/GDI turns `SurfacePaint`, `TextPaint`, `DividerPaint`, `ProgressPaint`, and `WidgetPaint` into brushes, pens, and text colors; X11 turns the same values into allocated pixels and primitive draws.
 
 **No UI framework** -- Direct Win32 + GDI. The app is ~2800 lines total; a framework would add more complexity than it removes. GDI objects are managed with RAII wrappers (`GdiObj`, `DcObj`, `IconObj` in `gdi.hpp`).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,17 +8,35 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_program(LLD NAMES ld.lld ld.lld.exe)
 
-# Cross-platform sources (no Windows.h dependency)
-set(CHRONOS_SOURCES
-    src/main.cpp
+add_library(chronos_project_options INTERFACE)
+target_compile_options(chronos_project_options INTERFACE
+    -Wall -Wextra -Werror $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-command-line-argument>
+)
+
+function(chronos_use_lld target)
+    if(LLD)
+        target_link_options(${target} PRIVATE "--ld-path=${LLD}")
+    endif()
+endfunction()
+
+# Logic-portable sources shared by the desktop app and unit tests.
+# Keep Windows.h-dependent files in the platform sections below.
+set(CHRONOS_CORE_SOURCES
     src/actions.cpp
     src/config_serial.cpp
     src/encoding.cpp
     src/formatting.cpp
 )
 
+add_library(chronos_core STATIC ${CHRONOS_CORE_SOURCES})
+target_include_directories(chronos_core PUBLIC src)
+target_link_libraries(chronos_core PUBLIC chronos_project_options)
+set_target_properties(chronos_core PROPERTIES CXX_SCAN_FOR_MODULES OFF)
+
+set(CHRONOS_APP_SOURCES src/main.cpp)
+
 if(WIN32)
-    list(APPEND CHRONOS_SOURCES
+    list(APPEND CHRONOS_APP_SOURCES
         src/config_io.cpp
         src/dialog_style.cpp
         src/input_core.cpp
@@ -35,9 +53,9 @@ if(WIN32)
         src/ui_windows_app.cpp
         src/ui_windows_settings_dialog.cpp
     )
-    add_executable(chronos WIN32 ${CHRONOS_SOURCES})
+    add_executable(chronos WIN32 ${CHRONOS_APP_SOURCES})
 
-    target_include_directories(chronos PRIVATE src)
+    target_link_libraries(chronos PRIVATE chronos_core)
     set_target_properties(chronos PROPERTIES CXX_SCAN_FOR_MODULES OFF)
 
     target_compile_definitions(chronos PRIVATE
@@ -47,17 +65,11 @@ if(WIN32)
         _UNICODE
     )
 
-    target_compile_options(chronos PRIVATE
-        -Wall -Wextra -Werror $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-command-line-argument>
-    )
-
     target_link_options(chronos PRIVATE
         -static-libstdc++
         -static-libgcc
     )
-    if(LLD)
-        target_link_options(chronos PRIVATE "--ld-path=${LLD}")
-    endif()
+    chronos_use_lld(chronos)
 
     target_link_libraries(chronos PRIVATE
         -Wl,-Bstatic winpthread -Wl,-Bdynamic
@@ -65,14 +77,10 @@ if(WIN32)
     )
 elseif(UNIX AND NOT APPLE)
     find_package(X11 REQUIRED)
-    list(APPEND CHRONOS_SOURCES src/ui_linux.cpp)
-    add_executable(chronos ${CHRONOS_SOURCES})
-    target_include_directories(chronos PRIVATE src)
+    list(APPEND CHRONOS_APP_SOURCES src/ui_linux.cpp)
+    add_executable(chronos ${CHRONOS_APP_SOURCES})
+    target_link_libraries(chronos PRIVATE chronos_core X11::X11)
     set_target_properties(chronos PROPERTIES CXX_SCAN_FOR_MODULES OFF)
-    target_compile_options(chronos PRIVATE
-        -Wall -Wextra -Werror $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-command-line-argument>
-    )
-    target_link_libraries(chronos PRIVATE X11::X11)
 endif()
 
 # Copy compile_commands.json to repo root after build so all editors find it
@@ -105,20 +113,10 @@ if(BUILD_TESTS)
         tests/test_actions_timer.cpp
         tests/test_actions_adjust.cpp
         tests/test_pomodoro.cpp
-        src/actions.cpp
-        src/config_serial.cpp
-        src/encoding.cpp
-        src/formatting.cpp
     )
-    target_include_directories(chronos_tests PRIVATE src)
     set_target_properties(chronos_tests PROPERTIES CXX_SCAN_FOR_MODULES OFF)
-    target_link_libraries(chronos_tests PRIVATE Catch2::Catch2WithMain)
-    target_compile_options(chronos_tests PRIVATE
-        -Wall -Wextra -Werror $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-command-line-argument>
-    )
-    if(LLD)
-        target_link_options(chronos_tests PRIVATE "--ld-path=${LLD}")
-    endif()
+    target_link_libraries(chronos_tests PRIVATE chronos_core Catch2::Catch2WithMain)
+    chronos_use_lld(chronos_tests)
     if(WIN32)
         target_compile_definitions(chronos_tests PRIVATE
             WIN32_LEAN_AND_MEAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ target_compile_options(chronos_project_options INTERFACE
 
 function(chronos_use_lld target)
     if(LLD)
-        target_link_options(${target} PRIVATE "--ld-path=${LLD}")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            target_link_options(${target} PRIVATE "--ld-path=${LLD}")
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_link_options(${target} PRIVATE "-fuse-ld=lld")
+        endif()
     endif()
 endfunction()
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Any editor using clangd (Neovim, VS Code with clangd extension, etc.) gets full 
 
 The primary application is the **Windows** desktop UI, implemented with Win32 and GDI.
 
-Linux builds use an experimental X11/Xlib backend that opens a minimal Chronos window and renders the current clock. It is intentionally smaller than the Windows UI while the platform layer is being split out. The logic-portable layer (timers, stopwatch, config serialization, Pomodoro state machine, formatting) has no Win32 dependencies and compiles on Linux. CI runs the unit test suite on Linux to verify this layer independently of the Windows UI.
+Linux builds use an experimental X11/Xlib backend that renders the shared main Chronos scene through a lightweight X11 adapter. It now drives the same `App` state and action dispatcher for core keyboard and mouse interactions (start/stop stopwatch, laps, reset, timer start/reset/add/remove, clock/theme toggles) while the platform layer is being split out. Windows remains the primary, fully native desktop UI with dialogs, tray integration, label editing, and full mouse handling. The logic-portable layer (timers, stopwatch, config serialization, Pomodoro state machine, formatting) has no Win32 dependencies and compiles on Linux. CI runs the unit test suite on Linux to verify this layer independently of the Windows UI.
 
 ### Debugging
 

--- a/src/alarm_dialog.cpp
+++ b/src/alarm_dialog.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include "alarm.hpp"
 #include "dialog_style.hpp"
+#include "ui_windows_painter.hpp"
 #include "encoding.hpp"
 
 namespace alarm_dlg {
@@ -104,19 +105,11 @@ static void init_painted_rects(HWND dlg, Params& p) {
 
 static void paint_toggle_btn(HDC hdc, const RECT& r, const wchar_t* text, bool active,
                               const DlgStyle& s) {
-    int rr = s.scale(4);
-    HBRUSH br = CreateSolidBrush(active ? s.theme->active : s.theme->btn);
-    HPEN   pn = CreatePen(PS_NULL, 0, 0);
-    auto* obr = (HBRUSH)SelectObject(hdc, br);
-    auto* opn = (HPEN)SelectObject(hdc, pn);
-    RoundRect(hdc, r.left, r.top, r.right, r.bottom, rr, rr);
-    SelectObject(hdc, obr); SelectObject(hdc, opn);
-    DeleteObject(br); DeleteObject(pn);
-    SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, s.theme->text);
-    SelectObject(hdc, s.font);
-    RECT rc = r;
-    DrawTextW(hdc, text, -1, &rc, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    WidgetPaint button = make_button(s.theme->palette, ButtonConfig{
+                                                           .active = active,
+                                                           .radius_px = s.scale(4),
+                                                       });
+    win_paint_button(hdc, r, text, s.font, button);
 }
 
 // ─── Dialog procedure ─────────────────────────────────────────────────────────

--- a/src/dialog_style.cpp
+++ b/src/dialog_style.cpp
@@ -38,7 +38,6 @@ void DlgStyle::draw_button(HDC hdc, const RECT& rc, const wchar_t* text, bool fo
     GdiObj bg_br = win_brush(theme->palette.bg);
     FillRect(hdc, &rc, (HBRUSH)bg_br.h);
     WidgetPaint button = make_button(theme->palette, ButtonConfig{
-                                                         .active = focused,
                                                          .focused = focused,
                                                          .radius_px = scale(6),
                                                      });

--- a/src/dialog_style.cpp
+++ b/src/dialog_style.cpp
@@ -1,15 +1,19 @@
 #include "dialog_style.hpp"
+#include "ui_windows_painter.hpp"
 #include <windowsx.h>
 
-void dlg_add_item(DlgBuf& b, DWORD style, short x, short y, short cx, short cy,
-                  WORD id, WORD cls_atom, const wchar_t* title) {
+void dlg_add_item(DlgBuf& b, DWORD style, short x, short y, short cx, short cy, WORD id, WORD cls_atom,
+                  const wchar_t* title) {
     b.align4();
     b.push_dword(WS_CHILD | WS_VISIBLE | style);
     b.push_dword(0);
-    b.push_word((WORD)x); b.push_word((WORD)y);
-    b.push_word((WORD)cx); b.push_word((WORD)cy);
+    b.push_word((WORD)x);
+    b.push_word((WORD)y);
+    b.push_word((WORD)cx);
+    b.push_word((WORD)cy);
     b.push_word(id);
-    b.push_word(0xFFFF); b.push_word(cls_atom);
+    b.push_word(0xFFFF);
+    b.push_word(cls_atom);
     b.push_wstr(title);
     b.push_word(0);
 }
@@ -21,42 +25,27 @@ void DlgStyle::apply_dark_mode(HWND hwnd) const {
 }
 
 void DlgStyle::fill_background(HDC hdc, const RECT& rc) const {
-    HBRUSH br = CreateSolidBrush(theme->bg);
-    FillRect(hdc, &rc, br);
-    DeleteObject(br);
+    DialogPaint dialog = make_dialog(theme->palette, DialogConfig{});
+    GdiObj br = win_brush(dialog.background);
+    FillRect(hdc, &rc, (HBRUSH)br.h);
 }
 
 void DlgStyle::draw_label(HDC hdc, const RECT& rc, const wchar_t* text, UINT fmt) const {
-    SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, theme->text);
-    SelectObject(hdc, font);
-    RECT r = rc;
-    DrawTextW(hdc, text, -1, &r, fmt);
+    win_paint_label(hdc, rc, text, font, theme->palette, fmt);
 }
 
 void DlgStyle::draw_button(HDC hdc, const RECT& rc, const wchar_t* text, bool focused) const {
-    HBRUSH bg_br = CreateSolidBrush(theme->bg);
-    FillRect(hdc, &rc, bg_br);
-    DeleteObject(bg_br);
-    int rr = scale(6);
-    HBRUSH br = CreateSolidBrush(focused ? theme->active : theme->btn);
-    HPEN pen = CreatePen(PS_NULL, 0, 0);
-    auto* obr = (HBRUSH)SelectObject(hdc, br);
-    auto* opn = (HPEN)SelectObject(hdc, pen);
-    RoundRect(hdc, rc.left, rc.top, rc.right, rc.bottom, rr, rr);
-    SelectObject(hdc, obr);
-    SelectObject(hdc, opn);
-    DeleteObject(br);
-    DeleteObject(pen);
-    SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, theme->text);
-    SelectObject(hdc, font);
-    RECT r = rc;
-    DrawTextW(hdc, text, -1, &r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    GdiObj bg_br = win_brush(theme->palette.bg);
+    FillRect(hdc, &rc, (HBRUSH)bg_br.h);
+    WidgetPaint button = make_button(theme->palette, ButtonConfig{
+                                                         .active = focused,
+                                                         .focused = focused,
+                                                         .radius_px = scale(6),
+                                                     });
+    win_paint_button(hdc, rc, text, font, button);
 }
 
-void DlgStyle::draw_check_radio(HDC hdc, const RECT& rc, const wchar_t* text,
-                                 bool checked, bool is_radio) const {
+void DlgStyle::draw_check_radio(HDC hdc, const RECT& rc, const wchar_t* text, bool checked, bool is_radio) const {
     HBRUSH bg_br = CreateSolidBrush(theme->bg);
     FillRect(hdc, &rc, bg_br);
     DeleteObject(bg_br);
@@ -65,7 +54,7 @@ void DlgStyle::draw_check_radio(HDC hdc, const RECT& rc, const wchar_t* text,
     int gs = scale(10);
     if (gs > h - 2) gs = h - 2;
     int gy = rc.top + (h - gs) / 2;
-    RECT g = { rc.left + 2, gy, rc.left + 2 + gs, gy + gs };
+    RECT g = {rc.left + 2, gy, rc.left + 2 + gs, gy + gs};
 
     HPEN pen = CreatePen(PS_SOLID, 1, theme->text);
     HBRUSH fill = CreateSolidBrush(theme->bar);
@@ -100,7 +89,7 @@ void DlgStyle::draw_check_radio(HDC hdc, const RECT& rc, const wchar_t* text,
     SetBkMode(hdc, TRANSPARENT);
     SetTextColor(hdc, theme->text);
     SelectObject(hdc, font);
-    RECT tr = { rc.left + gs + 6, rc.top, rc.right, rc.bottom };
+    RECT tr = {rc.left + gs + 6, rc.top, rc.right, rc.bottom};
     DrawTextW(hdc, text, -1, &tr, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
 }
 
@@ -108,9 +97,9 @@ void DlgStyle::draw_check_radio(HDC hdc, const RECT& rc, const wchar_t* text,
 
 DialogBrushes DialogBrushes::create(const Theme& theme) {
     return DialogBrushes{
-        .bg   = GdiObj{CreateSolidBrush(theme.bg)},
+        .bg = GdiObj{CreateSolidBrush(theme.bg)},
         .edit = GdiObj{CreateSolidBrush(theme.bar)},
-        .btn  = GdiObj{CreateSolidBrush(theme.bg)},
+        .btn = GdiObj{CreateSolidBrush(theme.bg)},
     };
 }
 
@@ -122,19 +111,21 @@ void dialog_center_on_parent(HWND dlg) {
     GetWindowRect(dlg, &dr);
     int dw = dr.right - dr.left, dh = dr.bottom - dr.top;
     int x = pr.left + (pr.right - pr.left - dw) / 2;
-    int y = pr.top  + (pr.bottom - pr.top  - dh) / 2;
+    int y = pr.top + (pr.bottom - pr.top - dh) / 2;
     SetWindowPos(dlg, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 }
 
 void dialog_apply_font_to_children(HWND dlg, HFONT font) {
-    EnumChildWindows(dlg, [](HWND child, LPARAM param) -> BOOL {
-        SendMessageW(child, WM_SETFONT, (WPARAM)param, FALSE);
-        return TRUE;
-    }, (LPARAM)font);
+    EnumChildWindows(
+        dlg,
+        [](HWND child, LPARAM param) -> BOOL {
+            SendMessageW(child, WM_SETFONT, (WPARAM)param, FALSE);
+            return TRUE;
+        },
+        (LPARAM)font);
 }
 
-INT_PTR dialog_handle_ctl_color(UINT msg, HDC hdc, const Theme& theme,
-                                const DialogBrushes& brushes) {
+INT_PTR dialog_handle_ctl_color(UINT msg, HDC hdc, const Theme& theme, const DialogBrushes& brushes) {
     switch (msg) {
     case WM_CTLCOLORSTATIC:
         SetTextColor(hdc, theme.text);
@@ -162,8 +153,7 @@ INT_PTR dialog_handle_caption_hittest(HWND dlg, LPARAM lp, short title_h_dlu) {
     return 0;
 }
 
-void dialog_paint_title(HDC hdc, HWND dlg, const DlgStyle& style,
-                        const wchar_t* title, short title_h_dlu) {
+void dialog_paint_title(HDC hdc, HWND dlg, const DlgStyle& style, const wchar_t* title, short title_h_dlu) {
     RECT client{};
     GetClientRect(dlg, &client);
     RECT title_rc{0, 0, 0, title_h_dlu};
@@ -172,10 +162,10 @@ void dialog_paint_title(HDC hdc, HWND dlg, const DlgStyle& style,
     title_rc.right = client.right;
     style.draw_label(hdc, title_rc, title, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
-    HPEN pen = CreatePen(PS_SOLID, 1, style.theme->divider);
-    auto* old = (HPEN)SelectObject(hdc, pen);
+    DialogPaint dialog = make_dialog(style.theme->palette, DialogConfig{});
+    GdiObj pen = win_pen(dialog.divider);
+    auto* old = (HPEN)SelectObject(hdc, pen.h);
     MoveToEx(hdc, 0, divider_y, nullptr);
     LineTo(hdc, client.right, divider_y);
     SelectObject(hdc, old);
-    DeleteObject(pen);
 }

--- a/src/icon.hpp
+++ b/src/icon.hpp
@@ -3,10 +3,13 @@
 #include <cmath>
 #include <cstring>
 #include "gdi.hpp"
+#include "ui_style.hpp"
 
 namespace icon_detail {
 
-struct Pixel { uint8_t b, g, r, a; };
+struct Pixel {
+    uint8_t b, g, r, a;
+};
 
 inline void blend(Pixel& dst, uint8_t r, uint8_t g, uint8_t b, float alpha) {
     if (alpha <= 0.f) return;
@@ -62,7 +65,10 @@ inline HICON create_app_icon(int size, bool dark = true) {
     if (!screen) return nullptr;
 
     HBITMAP dib = CreateDIBSection(screen, (BITMAPINFO*)&bih, DIB_RGB_COLORS, &bits, nullptr, 0);
-    if (!dib) { ReleaseDC(nullptr, screen); return nullptr; }
+    if (!dib) {
+        ReleaseDC(nullptr, screen);
+        return nullptr;
+    }
 
     GdiObj mask_bmp{CreateBitmap(size, size, 1, 1, nullptr)};
     ReleaseDC(nullptr, screen);
@@ -77,9 +83,10 @@ inline HICON create_app_icon(int size, bool dark = true) {
     float hand_w = size > 20 ? 1.6f : 1.1f;
     float tick_w = size > 20 ? 1.4f : 1.0f;
 
-    uint8_t cr, cg, cb;
-    if (dark) { cr = 210; cg = 210; cb = 215; }
-    else      { cr = 50;  cg = 50;  cb = 60;  }
+    IconPaint icon = make_icon(dark ? dark_palette : light_palette, IconConfig{});
+    uint8_t cr = icon.foreground.r;
+    uint8_t cg = icon.foreground.g;
+    uint8_t cb = icon.foreground.b;
 
     for (int y = 0; y < size; y++) {
         for (int x = 0; x < size; x++) {
@@ -97,12 +104,15 @@ inline HICON create_app_icon(int size, bool dark = true) {
     }
 
     const float pi = 3.14159265f;
-    struct Tick { float angle; float len; };
+    struct Tick {
+        float angle;
+        float len;
+    };
     Tick ticks[] = {
-        {0.f,           0.15f},
-        {pi * 0.5f,     0.12f},
-        {pi,            0.12f},
-        {pi * 1.5f,     0.15f},
+        {0.f, 0.15f},
+        {pi * 0.5f, 0.12f},
+        {pi, 0.12f},
+        {pi * 1.5f, 0.15f},
     };
     for (auto& t : ticks) {
         float inner = radius - size * t.len;
@@ -124,14 +134,17 @@ inline HICON create_app_icon(int size, bool dark = true) {
     }
 
     float hour_angle = pi * 2.f * (10.f / 12.f) - pi * 0.5f;
-    float min_angle  = pi * 2.f * (10.f / 60.f) - pi * 0.5f;
+    float min_angle = pi * 2.f * (10.f / 60.f) - pi * 0.5f;
     float hour_len = radius * 0.55f;
-    float min_len  = radius * 0.78f;
+    float min_len = radius * 0.78f;
 
-    struct Hand { float x1, y1, x2, y2; float w; };
+    struct Hand {
+        float x1, y1, x2, y2;
+        float w;
+    };
     Hand hands[] = {
         {cx, cy, cx + cosf(hour_angle) * hour_len, cy + sinf(hour_angle) * hour_len, hand_w * 1.2f},
-        {cx, cy, cx + cosf(min_angle) * min_len,   cy + sinf(min_angle) * min_len,   hand_w},
+        {cx, cy, cx + cosf(min_angle) * min_len, cy + sinf(min_angle) * min_len, hand_w},
     };
     for (auto& h : hands) {
         for (int y = 0; y < size; y++) {

--- a/src/icon.hpp
+++ b/src/icon.hpp
@@ -177,7 +177,7 @@ inline HICON create_app_icon(int size, bool dark = true) {
     ii.fIcon = TRUE;
     ii.hbmMask = (HBITMAP)mask_bmp.h;
     ii.hbmColor = dib;
-    HICON icon = CreateIconIndirect(&ii);
+    HICON hicon = CreateIconIndirect(&ii);
     DeleteObject(dib);
-    return icon;
+    return hicon;
 }

--- a/src/paint_ctx.hpp
+++ b/src/paint_ctx.hpp
@@ -7,6 +7,7 @@
 #include "gdi.hpp"
 #include "layout.hpp"
 #include "theme.hpp"
+#include "ui_windows_painter.hpp"
 
 // ─── Paint context ─────────────────────────────────────────────────
 struct PaintCtx {
@@ -24,32 +25,21 @@ inline RECT btn(HDC hdc, RECT r, bool active, const wchar_t* label, int id, Pain
                 std::optional<COLORREF> override_col = std::nullopt) {
     auto& layout = ctx.layout;
     bool blinking = id && ctx.app.blink_act == id && (ctx.now - ctx.app.blink_t) < BLINK_DUR;
-    HBRUSH brush;
-    GdiObj dyn_br{nullptr};
-    if (blinking) {
-        brush = ctx.res.brBlink;
-    } else if (override_col.has_value()) {
-        dyn_br.h = CreateSolidBrush(*override_col);
-        brush = (HBRUSH)dyn_br.h;
-    } else {
-        brush = active ? ctx.res.brActive : ctx.res.brBtn;
-    }
-    auto* obr = (HBRUSH)SelectObject(hdc, brush);
-    auto* opn = (HPEN)SelectObject(hdc, ctx.res.pnNull);
-    int rr = layout.dpi_scale(6);
-    RoundRect(hdc, r.left, r.top, r.right, r.bottom, rr, rr);
-    SelectObject(hdc, obr);
-    SelectObject(hdc, opn);
-    SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, ctx.theme.text);
-    DrawTextW(hdc, label, -1, &r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    std::optional<UiColor> override_ui;
+    if (override_col.has_value()) override_ui = ui_color_from_colorref(*override_col);
+    ButtonConfig button_config{
+        .active = active,
+        .blinking = blinking,
+        .fill_override = override_ui,
+        .radius_px = layout.dpi_scale(6),
+    };
+    WidgetPaint button = make_button(ctx.theme.palette, button_config);
+
+    win_paint_button(hdc, r, label, nullptr, button);
     if (id) ctx.btns.push_back({r, id});
     return r;
 }
 
 inline void divider(HDC hdc, int y, int cw, const PaintCtx& ctx) {
-    auto* op = (HPEN)SelectObject(hdc, ctx.res.pnDivider);
-    MoveToEx(hdc, 0, y, nullptr);
-    LineTo(hdc, cw, y);
-    SelectObject(hdc, op);
+    win_paint_divider(hdc, 0, cw, y, make_ui(ctx.theme.palette).divider());
 }

--- a/src/painting_analog.cpp
+++ b/src/painting_analog.cpp
@@ -18,34 +18,34 @@ COLORREF analog_pick_color(int configured, COLORREF fallback) {
 COLORREF analog_blend(COLORREF fg, COLORREF bg, int opacity_pct) {
     opacity_pct = std::clamp(opacity_pct, 0, 100);
     auto mix = [&](int f, int b) { return (f * opacity_pct + b * (100 - opacity_pct)) / 100; };
-    return RGB(mix(GetRValue(fg), GetRValue(bg)),
-               mix(GetGValue(fg), GetGValue(bg)),
-               mix(GetBValue(fg), GetBValue(bg)));
+    return RGB(mix(GetRValue(fg), GetRValue(bg)), mix(GetGValue(fg), GetGValue(bg)), mix(GetBValue(fg), GetBValue(bg)));
 }
 
-AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style,
-                                                   const Theme& theme) {
-    COLORREF background = analog_pick_color(style.background_color, theme.bg);
+AnalogResolvedColors resolve_analog_colors(const AnalogClockStyle& style, const Theme& theme) {
+    AnalogClockPaint clock = make_analog_clock(theme.palette, AnalogClockConfig{});
+    COLORREF background = analog_pick_color(style.background_color, colorref_from_ui(clock.background));
     COLORREF outline = analog_pick_color(style.face_outline_color,
-                         analog_pick_color(style.face_color, theme.divider));
+                                         analog_pick_color(style.face_color, colorref_from_ui(clock.outline)));
+    COLORREF text = colorref_from_ui(clock.text);
+    COLORREF tick = colorref_from_ui(clock.tick);
     return {
-        .hour        = analog_blend(analog_pick_color(style.hour_color, theme.text), background, style.hour_opacity_pct),
-        .minute      = analog_blend(analog_pick_color(style.minute_color, theme.text), background, style.minute_opacity_pct),
-        .second      = analog_blend(analog_pick_color(style.second_color, theme.dim), background, style.second_opacity_pct),
-        .background  = background,
-        .face_fill   = analog_blend(analog_pick_color(style.face_fill_color, background), background, style.face_opacity_pct),
-        .face_outline= analog_blend(outline, background, style.face_opacity_pct),
-        .tick        = analog_blend(analog_pick_color(style.tick_color, theme.dim), background, style.tick_opacity_pct),
-        .hour_label  = analog_blend(analog_pick_color(style.hour_label_color,
-                                          analog_pick_color(style.tick_color, theme.dim)), background, style.tick_opacity_pct),
-        .center_dot  = analog_blend(analog_pick_color(style.center_dot_color,
-                                          analog_pick_color(style.hour_color, theme.text)), background, style.hour_opacity_pct),
+        .hour = analog_blend(analog_pick_color(style.hour_color, text), background, style.hour_opacity_pct),
+        .minute = analog_blend(analog_pick_color(style.minute_color, text), background, style.minute_opacity_pct),
+        .second = analog_blend(analog_pick_color(style.second_color, tick), background, style.second_opacity_pct),
+        .background = background,
+        .face_fill =
+            analog_blend(analog_pick_color(style.face_fill_color, background), background, style.face_opacity_pct),
+        .face_outline = analog_blend(outline, background, style.face_opacity_pct),
+        .tick = analog_blend(analog_pick_color(style.tick_color, tick), background, style.tick_opacity_pct),
+        .hour_label = analog_blend(analog_pick_color(style.hour_label_color, analog_pick_color(style.tick_color, tick)),
+                                   background, style.tick_opacity_pct),
+        .center_dot = analog_blend(analog_pick_color(style.center_dot_color, analog_pick_color(style.hour_color, text)),
+                                   background, style.hour_opacity_pct),
     };
 }
 
-void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
-                                      const Theme& theme, int dpi,
-                                      int hour, int minute, int second) {
+void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style, const Theme& theme, int dpi, int hour,
+                              int minute, int second) {
     auto colors = resolve_analog_colors(style, theme);
 
     int cx = (area.left + area.right) / 2;
@@ -58,9 +58,7 @@ void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
 
     auto dpi_px = [&](int base) { return std::max(1, base * dpi / STANDARD_DPI); };
 
-    auto angle_rad = [](double units, double total) {
-        return (units / total) * 2.0 * M_PI - M_PI / 2.0;
-    };
+    auto angle_rad = [](double units, double total) { return (units / total) * 2.0 * M_PI - M_PI / 2.0; };
 
     auto line_from_center = [&](double angle, int len, COLORREF color, int thickness) {
         GdiObj pen{CreatePen(PS_SOLID, dpi_px(thickness), color)};
@@ -110,14 +108,13 @@ void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
         SetBkMode(hdc, TRANSPARENT);
         SetTextColor(hdc, colors.hour_label);
         int label_font_h = -MulDiv(7, dpi, 72);
-        GdiObj label_font{CreateFontW(label_font_h, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
-                                       DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
-                                       CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"Segoe UI")};
+        GdiObj label_font{CreateFontW(label_font_h, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+                                      OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
+                                      DEFAULT_PITCH | FF_DONTCARE, L"Segoe UI")};
         auto* old_font = (HFONT)SelectObject(hdc, label_font.h);
         int label_r = radius - radius * style.hour_tick_pct / 100 - dpi_px(6);
         for (int i = 1; i <= 12; ++i) {
-            if (style.hour_labels == HourLabels::Sparse && i != 12 && i != 3 && i != 6 && i != 9)
-                continue;
+            if (style.hour_labels == HourLabels::Sparse && i != 12 && i != 3 && i != 6 && i != 9) continue;
             double a = angle_rad(i, 12.0);
             int lx = cx + (int)std::lround(std::cos(a) * label_r);
             int ly = cy + (int)std::lround(std::sin(a) * label_r);
@@ -153,9 +150,8 @@ void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
     }
 }
 
-void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
-                               const Theme& theme, int dpi,
-                               int hour, int minute, int second) {
+void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style, const Theme& theme, int dpi, int hour,
+                       int minute, int second) {
     int w = area.right - area.left;
     int h = area.bottom - area.top;
     if (w <= 0 || h <= 0) return;
@@ -182,18 +178,15 @@ void draw_analog_clock(HDC hdc, RECT area, const AnalogClockStyle& style,
     if (saved_dc != 0) {
         SetStretchBltMode(hdc, HALFTONE);
         SetBrushOrgEx(hdc, 0, 0, nullptr);
-        blit_ok = StretchBlt(hdc, area.left, area.top, w, h,
-                             mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
+        blit_ok = StretchBlt(hdc, area.left, area.top, w, h, mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
         RestoreDC(hdc, saved_dc);
     } else {
         int old_mode = SetStretchBltMode(hdc, HALFTONE);
         SetBrushOrgEx(hdc, 0, 0, nullptr);
-        blit_ok = StretchBlt(hdc, area.left, area.top, w, h,
-                             mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
+        blit_ok = StretchBlt(hdc, area.left, area.top, w, h, mem_dc.h, 0, 0, w * AA_SCALE, h * AA_SCALE, SRCCOPY);
         SetStretchBltMode(hdc, old_mode);
     }
 
     SelectObject(mem_dc.h, old_bmp);
-    if (!blit_ok)
-        draw_analog_clock_native(hdc, area, style, theme, dpi, hour, minute, second);
+    if (!blit_ok) draw_analog_clock_native(hdc, area, style, theme, dpi, hour, minute, second);
 }

--- a/src/painting_timer.cpp
+++ b/src/painting_timer.cpp
@@ -22,7 +22,7 @@ void paint_timer_progress(HDC hdc, int cw, int y, int i, std::chrono::steady_clo
     auto& layout = ctx.layout;
     auto& ts = ctx.app.timers[i];
     bool expired = ts.t.expired(now);
-    HBRUSH fillbr = expired ? ctx.res.brFillExp : ctx.res.brFill;
+    ProgressPaint progress = make_ui(ctx.theme.palette).progress(ProgressConfig{.expired = expired});
     int fw = cw;
     if (!expired) {
         using namespace std::chrono;
@@ -31,7 +31,7 @@ void paint_timer_progress(HDC hdc, int cw, int y, int i, std::chrono::steady_clo
         fw = total > 0 ? std::clamp((int)(cw * (double)(total - rem) / total), 0, cw) : 0;
     }
     RECT fr{0, y, fw, y + layout.tmr_h};
-    FillRect(hdc, &fr, fillbr);
+    win_paint_progress(hdc, fr, progress);
 }
 
 void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
@@ -78,11 +78,11 @@ void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     } else {
         SelectObject(hdc, ctx.res.fontBig);
         SetTextColor(hdc, th.text);
-        int field_h    = layout.dpi_scale(40);
-        int td_y       = y + m.td_off;
+        int field_h = layout.dpi_scale(40);
+        int td_y = y + m.td_off;
         int field_half = layout.dpi_scale(22);
         long long total_s_edit = ts.dur.count();
-        auto h_s  = std::format(L"{}", total_s_edit / 3600);
+        auto h_s = std::format(L"{}", total_s_edit / 3600);
         auto mm_s = std::format(L"{:02}", (total_s_edit / 60) % 60);
         auto ss_s = std::format(L"{:02}", total_s_edit % 60);
         RECT hr{hh_cx - field_half, td_y, hh_cx + field_half, td_y + field_h};
@@ -91,7 +91,7 @@ void paint_timer_idle(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
         DrawTextW(hdc, h_s.c_str(), -1, &hr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         DrawTextW(hdc, mm_s.c_str(), -1, &mr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
         DrawTextW(hdc, ss_s.c_str(), -1, &sr, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
-        int sep_w   = layout.dpi_scale(8);
+        int sep_w = layout.dpi_scale(8);
         int sep1_cx = (hh_cx + mm_cx) / 2;
         int sep2_cx = (mm_cx + ss_cx) / 2;
         RECT sep1r{sep1_cx - sep_w / 2, td_y, sep1_cx + sep_w / 2, td_y + field_h};
@@ -124,7 +124,8 @@ void paint_timer_running(HDC hdc, int cw, int y, int i, std::chrono::steady_cloc
 
     SelectObject(hdc, ctx.res.fontSm);
     SetTextColor(hdc, th.dim);
-    std::wstring subtitle = ts.label.empty() ? format_timer_edit(std::chrono::duration_cast<Timer::dur>(ts.dur)) : ts.label;
+    std::wstring subtitle =
+        ts.label.empty() ? format_timer_edit(std::chrono::duration_cast<Timer::dur>(ts.dur)) : ts.label;
     if (ts.pomodoro && ts.pomodoro_work_elapsed.count() > 0)
         subtitle += L" \u00B7 " + format_worked_time(ts.pomodoro_work_elapsed);
     RECT sr{0, y + m.up_off, cw, y + m.up_off + layout.dpi_scale(20)};
@@ -167,11 +168,10 @@ void paint_timer_controls(HDC hdc, int cw, int y, int i, PaintCtx& ctx) {
     int pm_sz = layout.dpi_scale(22), pm_margin = layout.dpi_scale(6);
     int pm_top = y + layout.tmr_h - pm_sz;
     if ((int)ctx.app.timers.size() < Config::MAX_TIMERS)
-        btn(hdc, {cw - pm_margin - pm_sz, pm_top, cw - pm_margin, pm_top + pm_sz}, false, L"+",
-            tmr_act(i, A_TMR_ADD), ctx);
+        btn(hdc, {cw - pm_margin - pm_sz, pm_top, cw - pm_margin, pm_top + pm_sz}, false, L"+", tmr_act(i, A_TMR_ADD),
+            ctx);
     if ((int)ctx.app.timers.size() > 1)
-        btn(hdc, {pm_margin, pm_top, pm_margin + pm_sz, pm_top + pm_sz}, false, L"\u2212",
-            tmr_act(i, A_TMR_DEL), ctx);
+        btn(hdc, {pm_margin, pm_top, pm_margin + pm_sz, pm_top + pm_sz}, false, L"\u2212", tmr_act(i, A_TMR_DEL), ctx);
 }
 
 int paint_timers(HDC hdc, int cw, int y, PaintCtx& ctx, std::chrono::steady_clock::time_point now) {

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -2,10 +2,23 @@
 #include <windows.h>
 #include <chrono>
 
+#include "ui_style.hpp"
+
 constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_ATTR = 20;
+
+constexpr COLORREF colorref_from_ui(UiColor color) { return RGB(color.r, color.g, color.b); }
+
+constexpr UiColor ui_color_from_colorref(COLORREF color) {
+    return UiColor{
+        static_cast<std::uint8_t>(color & 0xFF),
+        static_cast<std::uint8_t>((color >> 8) & 0xFF),
+        static_cast<std::uint8_t>((color >> 16) & 0xFF),
+    };
+}
 
 // ─── Theme ────────────────────────────────────────────────────────────────────
 struct Theme {
+    ThemePalette palette;
     COLORREF bg;
     COLORREF bar;
     COLORREF btn;
@@ -21,37 +34,27 @@ struct Theme {
     COLORREF divider;
 };
 
-constexpr Theme dark_theme{
-    .bg = RGB(26, 26, 26),
-    .bar = RGB(35, 35, 38),
-    .btn = RGB(40, 40, 44),
-    .active = RGB(80, 80, 88),
-    .text = RGB(204, 204, 204),
-    .dim = RGB(90, 90, 90),
-    .warn = RGB(240, 140, 30),
-    .expire = RGB(200, 50, 50),
-    .blink = RGB(110, 110, 118),
-    .fill = RGB(38, 38, 50),
-    .fill_exp = RGB(72, 18, 18),
-    .help_bg = RGB(20, 20, 20),
-    .divider = RGB(50, 50, 55),
-};
+constexpr Theme make_theme(const ThemePalette& palette) {
+    return Theme{
+        .palette = palette,
+        .bg = colorref_from_ui(palette.bg),
+        .bar = colorref_from_ui(palette.bar),
+        .btn = colorref_from_ui(palette.btn),
+        .active = colorref_from_ui(palette.active),
+        .text = colorref_from_ui(palette.text),
+        .dim = colorref_from_ui(palette.dim),
+        .warn = colorref_from_ui(palette.warn),
+        .expire = colorref_from_ui(palette.expire),
+        .blink = colorref_from_ui(palette.blink),
+        .fill = colorref_from_ui(palette.fill),
+        .fill_exp = colorref_from_ui(palette.fill_exp),
+        .help_bg = colorref_from_ui(palette.help_bg),
+        .divider = colorref_from_ui(palette.divider),
+    };
+}
 
-constexpr Theme light_theme{
-    .bg = RGB(243, 243, 243),
-    .bar = RGB(228, 228, 232),
-    .btn = RGB(214, 214, 220),
-    .active = RGB(175, 175, 188),
-    .text = RGB(28, 28, 28),
-    .dim = RGB(138, 138, 138),
-    .warn = RGB(196, 90, 0),
-    .expire = RGB(196, 36, 36),
-    .blink = RGB(168, 168, 178),
-    .fill = RGB(208, 208, 230),
-    .fill_exp = RGB(240, 196, 196),
-    .help_bg = RGB(232, 232, 232),
-    .divider = RGB(198, 198, 208),
-};
+constexpr Theme dark_theme = make_theme(dark_palette);
+constexpr Theme light_theme = make_theme(light_palette);
 
 // ─── Blink duration ──────────────────────────────────────────────────────────
 constexpr auto BLINK_DUR = std::chrono::milliseconds{120};

--- a/src/ui_linux.cpp
+++ b/src/ui_linux.cpp
@@ -167,10 +167,11 @@ static int action_for_key(KeySym key, const App& app) {
     }
 }
 
-static void handle_action(Display* display, Window window, GC gc, int width, int& height, App& app, int act) {
+static void handle_action(Display* display, Window window, GC gc, int width, int& height, App& app, int act,
+                          const std::filesystem::path& temp_dir) {
     if (act == 0) return;
     auto action_now = std::chrono::steady_clock::now();
-    auto result = dispatch_action(app, act, action_now, std::filesystem::temp_directory_path());
+    auto result = dispatch_action(app, act, action_now, temp_dir);
     if (result.resize) {
         Layout layout;
         height = scene_height(layout, app, action_now);
@@ -184,6 +185,10 @@ static void handle_action(Display* display, Window window, GC gc, int width, int
 int run_app(InstanceHandle, int) {
     x11::DisplayHandle display{XOpenDisplay(nullptr)};
     if (!display.display) return 1;
+
+    std::error_code temp_ec;
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path(temp_ec);
+    if (temp_ec) temp_dir = std::filesystem::current_path();
 
     App app;
     Layout layout;
@@ -225,13 +230,13 @@ int run_app(InstanceHandle, int) {
                     running = false;
                     break;
                 }
-                x11::handle_action(display.display, window, gc, width, height, app, x11::action_for_key(key, app));
+                x11::handle_action(display.display, window, gc, width, height, app, x11::action_for_key(key, app), temp_dir);
                 break;
             }
             case ButtonPress: {
                 auto scene = x11::current_scene(width, app);
                 int act = ui_scene::hit_test(scene, ev.xbutton.x, ev.xbutton.y);
-                x11::handle_action(display.display, window, gc, width, height, app, act);
+                x11::handle_action(display.display, window, gc, width, height, app, act, temp_dir);
                 break;
             }
             case ClientMessage:

--- a/src/ui_linux.cpp
+++ b/src/ui_linux.cpp
@@ -1,6 +1,13 @@
 #include "ui_linux.hpp"
+#include "actions.hpp"
+#include "app.hpp"
+#include "layout.hpp"
+#include "ui_scene.hpp"
+#include "ui_style.hpp"
+#include <algorithm>
 #include <chrono>
 #include <ctime>
+#include <filesystem>
 #include <string>
 #include <thread>
 
@@ -11,36 +18,165 @@ namespace x11 {
 struct DisplayHandle {
     Display* display = nullptr;
     explicit DisplayHandle(Display* d = nullptr) : display(d) {}
-    ~DisplayHandle() { if (display) XCloseDisplay(display); }
+    ~DisplayHandle() {
+        if (display) XCloseDisplay(display);
+    }
     DisplayHandle(const DisplayHandle&) = delete;
     DisplayHandle& operator=(const DisplayHandle&) = delete;
 };
 
-static std::string current_time_text() {
+static std::string current_time_text(ClockView view) {
     auto now = std::chrono::system_clock::now();
     std::time_t t = std::chrono::system_clock::to_time_t(now);
     std::tm tm{};
     localtime_r(&t, &tm);
-    char buf[16] = {};
-    std::strftime(buf, sizeof(buf), "%H:%M:%S", &tm);
+    char buf[24] = {};
+    switch (view) {
+    case ClockView::H24_HMS:
+    case ClockView::Analog:
+        std::strftime(buf, sizeof(buf), "%H:%M:%S", &tm);
+        break;
+    case ClockView::H24_HM:
+        std::strftime(buf, sizeof(buf), "%H:%M", &tm);
+        break;
+    case ClockView::H12_HMS:
+        std::strftime(buf, sizeof(buf), "%I:%M:%S %p", &tm);
+        break;
+    case ClockView::H12_HM:
+        std::strftime(buf, sizeof(buf), "%I:%M %p", &tm);
+        break;
+    }
     return buf;
 }
 
-static void draw(Display* display, Window window, GC gc, int width, int height) {
-    int screen = DefaultScreen(display);
-    unsigned long bg = WhitePixel(display, screen);
-    unsigned long fg = BlackPixel(display, screen);
-    XSetForeground(display, gc, bg);
-    XFillRectangle(display, window, gc, 0, 0, (unsigned)width, (unsigned)height);
+static unsigned long pixel(Display* display, int screen, UiColor color) {
+    Colormap cmap = DefaultColormap(display, screen);
+    XColor xcolor{};
+    xcolor.red = static_cast<unsigned short>(color.r * 257);
+    xcolor.green = static_cast<unsigned short>(color.g * 257);
+    xcolor.blue = static_cast<unsigned short>(color.b * 257);
+    if (XAllocColor(display, cmap, &xcolor)) return xcolor.pixel;
+    return BlackPixel(display, screen);
+}
 
-    XSetForeground(display, gc, fg);
-    std::string title = "Chronos";
-    std::string time = current_time_text();
-    std::string hint = "Experimental X11 backend";
-    XDrawString(display, window, gc, 20, 34, title.c_str(), (int)title.size());
-    XDrawString(display, window, gc, 20, height / 2, time.c_str(), (int)time.size());
-    XDrawString(display, window, gc, 20, height - 24, hint.c_str(), (int)hint.size());
+static int text_x(const ui_scene::Op& op) {
+    constexpr int approx_char_w = 6;
+    int text_w = (int)op.text.size() * approx_char_w;
+    switch (op.align) {
+    case ui_scene::Align::Center:
+        return op.rect.left + std::max(0, ui_scene::width(op.rect) - text_w) / 2;
+    case ui_scene::Align::Right:
+        return op.rect.right - text_w;
+    case ui_scene::Align::Left:
+        return op.rect.left;
+    }
+    return op.rect.left;
+}
+
+static int text_y(const ui_scene::Op& op) {
+    constexpr int approx_text_h = 12;
+    return op.rect.top + std::max(approx_text_h, ui_scene::height(op.rect) + approx_text_h) / 2;
+}
+
+static void draw_scene(Display* display, Window window, GC gc, const ui_scene::Scene& scene) {
+    int screen = DefaultScreen(display);
+    for (const auto& op : scene.ops) {
+        switch (op.kind) {
+        case ui_scene::OpKind::FillRect:
+        case ui_scene::OpKind::Progress:
+            XSetForeground(display, gc, pixel(display, screen, op.fill));
+            XFillRectangle(display, window, gc, op.rect.left, op.rect.top, (unsigned)ui_scene::width(op.rect),
+                           (unsigned)ui_scene::height(op.rect));
+            break;
+        case ui_scene::OpKind::Divider:
+            XSetForeground(display, gc, pixel(display, screen, op.stroke));
+            XDrawLine(display, window, gc, op.rect.left, op.rect.top, op.rect.right, op.rect.top);
+            break;
+        case ui_scene::OpKind::Text:
+            XSetForeground(display, gc, pixel(display, screen, op.text_color));
+            XDrawString(display, window, gc, text_x(op), text_y(op), op.text.c_str(), (int)op.text.size());
+            break;
+        case ui_scene::OpKind::Button:
+            XSetForeground(display, gc, pixel(display, screen, op.fill));
+            XFillRectangle(display, window, gc, op.rect.left, op.rect.top, (unsigned)ui_scene::width(op.rect),
+                           (unsigned)ui_scene::height(op.rect));
+            XSetForeground(display, gc, pixel(display, screen, op.stroke));
+            XDrawRectangle(display, window, gc, op.rect.left, op.rect.top, (unsigned)ui_scene::width(op.rect),
+                           (unsigned)ui_scene::height(op.rect));
+            XSetForeground(display, gc, pixel(display, screen, op.text_color));
+            XDrawString(display, window, gc, text_x(op), text_y(op), op.text.c_str(), (int)op.text.size());
+            break;
+        }
+    }
+}
+
+static ui_scene::MainSceneState scene_state(const App& app, std::chrono::steady_clock::time_point now) {
+    return ui_scene::main_scene_state_from_app(app, now, current_time_text(app.clock_view));
+}
+
+static int scene_height(const Layout& layout, const App& app, std::chrono::steady_clock::time_point now) {
+    return ui_scene::main_scene_height(layout, scene_state(app, now));
+}
+
+static ui_scene::Scene current_scene(int width, const App& app) {
+    Layout layout;
+    const ThemePalette& palette = palette_for(UiStyleConfig{.theme_mode = app.theme_mode, .system_dark = true});
+    return ui_scene::build_main_scene(layout, width, scene_state(app, std::chrono::steady_clock::now()),
+                                      make_ui(palette));
+}
+
+static void draw(Display* display, Window window, GC gc, int width, const App& app) {
+    draw_scene(display, window, gc, current_scene(width, app));
     XFlush(display);
+}
+
+static int action_for_key(KeySym key, const App& app) {
+    if (key >= XK_1 && key <= XK_9) {
+        int idx = (int)(key - XK_1);
+        if (idx < (int)app.timers.size()) return tmr_act(idx, A_TMR_START);
+    }
+    switch (key) {
+    case XK_space:
+        return app.show_sw ? A_SW_START : tmr_act(0, A_TMR_START);
+    case XK_l:
+    case XK_L:
+        return A_SW_LAP;
+    case XK_r:
+    case XK_R:
+        return app.show_sw ? A_SW_RESET : tmr_act(0, A_TMR_RST);
+    case XK_plus:
+    case XK_equal:
+        return tmr_act(std::max(0, (int)app.timers.size() - 1), A_TMR_ADD);
+    case XK_minus:
+    case XK_underscore:
+        return tmr_act(std::max(0, (int)app.timers.size() - 1), A_TMR_DEL);
+    case XK_c:
+    case XK_C:
+        return A_CLK_CYCLE;
+    case XK_t:
+    case XK_T:
+        return A_TOPMOST;
+    case XK_d:
+    case XK_D:
+        return A_THEME;
+    case XK_a:
+    case XK_A:
+        return A_SHOW_ALARMS;
+    default:
+        return 0;
+    }
+}
+
+static void handle_action(Display* display, Window window, GC gc, int width, int& height, App& app, int act) {
+    if (act == 0) return;
+    auto action_now = std::chrono::steady_clock::now();
+    auto result = dispatch_action(app, act, action_now, std::filesystem::temp_directory_path());
+    if (result.resize) {
+        Layout layout;
+        height = scene_height(layout, app, action_now);
+        XResizeWindow(display, window, (unsigned)width, (unsigned)height);
+    }
+    draw(display, window, gc, width, app);
 }
 
 } // namespace x11
@@ -49,14 +185,17 @@ int run_app(InstanceHandle, int) {
     x11::DisplayHandle display{XOpenDisplay(nullptr)};
     if (!display.display) return 1;
 
+    App app;
+    Layout layout;
+    auto now = std::chrono::steady_clock::now();
+    int width = std::max(Config::MIN_WINDOW_W, layout.bar_min_client_w());
+    int height = x11::scene_height(layout, app, now);
     int screen = DefaultScreen(display.display);
-    int width = 360;
-    int height = 160;
     Window root = RootWindow(display.display, screen);
     Window window = XCreateSimpleWindow(display.display, root, 100, 100, (unsigned)width, (unsigned)height, 1,
                                         BlackPixel(display.display, screen), WhitePixel(display.display, screen));
     XStoreName(display.display, window, "Chronos");
-    XSelectInput(display.display, window, ExposureMask | StructureNotifyMask | KeyPressMask);
+    XSelectInput(display.display, window, ExposureMask | StructureNotifyMask | KeyPressMask | ButtonPressMask);
 
     Atom wm_delete = XInternAtom(display.display, "WM_DELETE_WINDOW", False);
     XSetWMProtocols(display.display, window, &wm_delete, 1);
@@ -72,16 +211,27 @@ int run_app(InstanceHandle, int) {
             XNextEvent(display.display, &ev);
             switch (ev.type) {
             case Expose:
-                x11::draw(display.display, window, gc, width, height);
+                x11::draw(display.display, window, gc, width, app);
                 break;
             case ConfigureNotify:
                 width = ev.xconfigure.width;
                 height = ev.xconfigure.height;
-                x11::draw(display.display, window, gc, width, height);
+                (void)height;
+                x11::draw(display.display, window, gc, width, app);
                 break;
             case KeyPress: {
                 KeySym key = XLookupKeysym(&ev.xkey, 0);
-                if (key == XK_Escape || key == XK_q || key == XK_Q) running = false;
+                if (key == XK_Escape || key == XK_q || key == XK_Q) {
+                    running = false;
+                    break;
+                }
+                x11::handle_action(display.display, window, gc, width, height, app, x11::action_for_key(key, app));
+                break;
+            }
+            case ButtonPress: {
+                auto scene = x11::current_scene(width, app);
+                int act = ui_scene::hit_test(scene, ev.xbutton.x, ev.xbutton.y);
+                x11::handle_action(display.display, window, gc, width, height, app, act);
                 break;
             }
             case ClientMessage:
@@ -92,7 +242,7 @@ int run_app(InstanceHandle, int) {
 
         auto now = std::chrono::steady_clock::now();
         if (now >= next_tick) {
-            x11::draw(display.display, window, gc, width, height);
+            x11::draw(display.display, window, gc, width, app);
             next_tick = now + std::chrono::seconds{1};
         }
         std::this_thread::sleep_for(std::chrono::milliseconds{16});

--- a/src/ui_scene.hpp
+++ b/src/ui_scene.hpp
@@ -142,7 +142,7 @@ inline void add_toolbar(Scene& scene, const Layout& layout, int client_w, const 
         {layout.w_set, "Settings", false, A_SETTINGS},
     };
 
-    int total_w = 5 * layout.bar_gap;
+    int total_w = (static_cast<int>(std::size(buttons)) - 1) * layout.bar_gap;
     for (const auto& b : buttons) total_w += b.width;
     int x = (client_w - total_w) / 2;
     int y = (layout.bar_h - layout.btn_h) / 2;

--- a/src/ui_scene.hpp
+++ b/src/ui_scene.hpp
@@ -1,0 +1,275 @@
+#pragma once
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "actions.hpp"
+#include "app.hpp"
+#include "encoding.hpp"
+#include "formatting.hpp"
+#include "layout.hpp"
+#include "ui_style.hpp"
+
+namespace ui_scene {
+
+struct RectI {
+    int left;
+    int top;
+    int right;
+    int bottom;
+};
+
+enum class Align { Left, Center, Right };
+
+enum class OpKind { FillRect, Divider, Text, Button, Progress };
+
+struct Op {
+    OpKind kind = OpKind::FillRect;
+    RectI rect{};
+    std::string text;
+    UiColor fill{};
+    UiColor stroke{};
+    UiColor text_color{};
+    int radius_px = 0;
+    Align align = Align::Left;
+    int id = 0;
+};
+
+struct Scene {
+    std::vector<Op> ops;
+};
+
+struct TimerSceneState {
+    bool running = false;
+    bool expired = false;
+    double progress = 0.0;
+    std::string text = "01:00";
+    std::string label = "Timer 1";
+};
+
+struct MainSceneState {
+    bool topmost = false;
+    bool show_clock = true;
+    bool show_stopwatch = true;
+    bool show_timers = true;
+    bool show_alarms = false;
+    bool stopwatch_running = false;
+    std::string clock_text = "00:00:00";
+    std::string stopwatch_text = "00:00.000";
+    std::vector<TimerSceneState> timers{{}};
+};
+
+inline int width(const RectI& r) { return r.right - r.left; }
+inline int height(const RectI& r) { return r.bottom - r.top; }
+
+inline void add_fill(Scene& scene, RectI rect, SurfacePaint paint) {
+    Op op{};
+    op.kind = OpKind::FillRect;
+    op.rect = rect;
+    op.fill = paint.background;
+    op.stroke = paint.border;
+    scene.ops.push_back(std::move(op));
+}
+
+inline void add_text(Scene& scene, RectI rect, std::string text, TextPaint paint, Align align = Align::Left,
+                     int id = 0) {
+    Op op{};
+    op.kind = OpKind::Text;
+    op.rect = rect;
+    op.text = std::move(text);
+    op.text_color = paint.color;
+    op.align = align;
+    op.id = id;
+    scene.ops.push_back(std::move(op));
+}
+
+inline void add_divider(Scene& scene, int x0, int x1, int y, DividerPaint paint) {
+    Op op{};
+    op.kind = OpKind::Divider;
+    op.rect = {x0, y, x1, y};
+    op.stroke = paint.color;
+    scene.ops.push_back(std::move(op));
+}
+
+inline void add_button(Scene& scene, RectI rect, std::string label, WidgetPaint paint, int id = 0) {
+    Op op{};
+    op.kind = OpKind::Button;
+    op.rect = rect;
+    op.text = std::move(label);
+    op.fill = paint.fill;
+    op.stroke = paint.border;
+    op.text_color = paint.text;
+    op.radius_px = paint.radius_px;
+    op.align = Align::Center;
+    op.id = id;
+    scene.ops.push_back(std::move(op));
+}
+
+inline void add_progress(Scene& scene, RectI rect, ProgressPaint paint) {
+    Op op{};
+    op.kind = OpKind::Progress;
+    op.rect = rect;
+    op.fill = paint.fill;
+    scene.ops.push_back(std::move(op));
+}
+
+inline void add_toolbar(Scene& scene, const Layout& layout, int client_w, const MainSceneState& state,
+                        const UiMakers& ui) {
+    add_fill(scene, {0, 0, client_w, layout.bar_h}, ui.surface(SurfaceConfig{.elevated = true}));
+
+    struct ToolbarButton {
+        int width;
+        const char* label;
+        bool active;
+        int action;
+    };
+    ToolbarButton buttons[] = {
+        {layout.w_pin, "Pin", state.topmost, A_TOPMOST},
+        {layout.w_clk, "Clock", state.show_clock, A_SHOW_CLK},
+        {layout.w_sw, "Stopwatch", state.show_stopwatch, A_SHOW_SW},
+        {layout.w_tmr, "Timers", state.show_timers, A_SHOW_TMR},
+        {layout.w_alm, "Alarms", state.show_alarms, A_SHOW_ALARMS},
+        {layout.w_set, "Settings", false, A_SETTINGS},
+    };
+
+    int total_w = 5 * layout.bar_gap;
+    for (const auto& b : buttons) total_w += b.width;
+    int x = (client_w - total_w) / 2;
+    int y = (layout.bar_h - layout.btn_h) / 2;
+    for (const auto& b : buttons) {
+        add_button(scene, {x, y, x + b.width, y + layout.btn_h}, b.label,
+                   ui.button(ButtonConfig{.active = b.active, .radius_px = layout.dpi_scale(6)}), b.action);
+        x += b.width + layout.bar_gap;
+    }
+}
+
+inline void add_clock(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
+                      const UiMakers& ui) {
+    if (!state.show_clock) return;
+    add_divider(scene, 0, client_w, y, ui.divider());
+    add_text(scene, {0, y, client_w, y + layout.clk_h}, state.clock_text, ui.text(), Align::Center, A_CLK_CYCLE);
+    y += layout.clk_h;
+}
+
+inline void add_stopwatch(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
+                          const UiMakers& ui) {
+    if (!state.show_stopwatch) return;
+    add_divider(scene, 0, client_w, y, ui.divider());
+    add_text(scene, {0, y + layout.dpi_scale(4), client_w, y + layout.dpi_scale(44)}, state.stopwatch_text, ui.text(),
+             Align::Center);
+
+    int bw = layout.dpi_scale(76);
+    int gap = layout.dpi_scale(6);
+    int bh = layout.dpi_scale(28);
+    int x0 = (client_w - 3 * bw - 2 * gap) / 2;
+    int by = y + layout.dpi_scale(50);
+    add_button(scene, {x0, by, x0 + bw, by + bh}, state.stopwatch_running ? "Stop" : "Start",
+               ui.button(ButtonConfig{.active = state.stopwatch_running, .radius_px = layout.dpi_scale(6)}),
+               A_SW_START);
+    add_button(scene, {x0 + bw + gap, by, x0 + 2 * bw + gap, by + bh}, "Lap",
+               ui.button(ButtonConfig{.radius_px = layout.dpi_scale(6)}), A_SW_LAP);
+    add_button(scene, {x0 + 2 * (bw + gap), by, x0 + 3 * bw + 2 * gap, by + bh}, "Reset",
+               ui.button(ButtonConfig{.radius_px = layout.dpi_scale(6)}), A_SW_RESET);
+    y += layout.sw_h;
+}
+
+inline void add_timer(Scene& scene, const Layout& layout, int client_w, int& y, int index, const TimerSceneState& timer,
+                      const UiMakers& ui) {
+    add_divider(scene, 0, client_w, y, ui.divider());
+
+    int progress_w = std::clamp((int)(client_w * timer.progress), 0, client_w);
+    if (progress_w > 0 || timer.expired) {
+        add_progress(scene, {0, y, timer.expired ? client_w : progress_w, y + layout.tmr_h},
+                     ui.progress(ProgressConfig{.expired = timer.expired}));
+    }
+
+    add_text(scene, {0, y + layout.dpi_scale(12), client_w, y + layout.dpi_scale(34)}, timer.label,
+             ui.text(TextConfig{.tone = TextTone::Dim}), Align::Center);
+    add_text(scene, {0, y + layout.dpi_scale(36), client_w, y + layout.dpi_scale(78)}, timer.text,
+             ui.text(timer.expired ? TextConfig{.tone = TextTone::Danger} : TextConfig{}), Align::Center);
+
+    int bw = layout.dpi_scale(86);
+    int gap = layout.dpi_scale(6);
+    int bh = layout.dpi_scale(28);
+    int x0 = (client_w - 2 * bw - gap) / 2;
+    int by = y + layout.dpi_scale(80);
+    add_button(scene, {x0, by, x0 + bw, by + bh}, timer.running ? "Pause" : "Start",
+               ui.button(ButtonConfig{.active = timer.running, .radius_px = layout.dpi_scale(6)}),
+               tmr_act(index, A_TMR_START));
+    add_button(scene, {x0 + bw + gap, by, x0 + 2 * bw + gap, by + bh}, "Reset",
+               ui.button(ButtonConfig{.radius_px = layout.dpi_scale(6)}), tmr_act(index, A_TMR_RST));
+    y += layout.tmr_h;
+}
+
+inline int main_scene_height(const Layout& layout, const MainSceneState& state) {
+    int h = layout.bar_h;
+    if (state.show_clock) h += layout.clk_h;
+    if (state.show_stopwatch) h += layout.sw_h;
+    if (state.show_timers) h += (int)state.timers.size() * layout.tmr_h;
+    return h;
+}
+
+inline Scene build_main_scene(const Layout& layout, int client_w, const MainSceneState& state, const UiMakers& ui) {
+    Scene scene;
+    add_fill(scene, {0, 0, client_w, main_scene_height(layout, state)}, ui.surface());
+    add_toolbar(scene, layout, client_w, state, ui);
+    int y = layout.bar_h;
+    add_clock(scene, layout, client_w, y, state, ui);
+    add_stopwatch(scene, layout, client_w, y, state, ui);
+    if (state.show_timers) {
+        for (int i = 0; i < (int)state.timers.size(); ++i)
+            add_timer(scene, layout, client_w, y, i, state.timers[i], ui);
+    }
+    return scene;
+}
+
+inline bool contains(const RectI& rect, int x, int y) {
+    return x >= rect.left && x < rect.right && y >= rect.top && y < rect.bottom;
+}
+
+inline int hit_test(const Scene& scene, int x, int y) {
+    for (auto it = scene.ops.rbegin(); it != scene.ops.rend(); ++it) {
+        if (it->id != 0 && contains(it->rect, x, y)) return it->id;
+    }
+    return 0;
+}
+
+inline MainSceneState main_scene_state_from_app(const App& app, std::chrono::steady_clock::time_point now,
+                                                std::string clock_text) {
+    using namespace std::chrono;
+    MainSceneState state{
+        .topmost = app.topmost,
+        .show_clock = app.show_clk,
+        .show_stopwatch = app.show_sw,
+        .show_timers = app.show_tmr,
+        .show_alarms = app.show_alarms,
+        .stopwatch_running = app.sw.is_running(),
+        .clock_text = std::move(clock_text),
+        .stopwatch_text = wide_to_utf8(format_stopwatch_display(app.sw.elapsed(now))),
+        .timers = {},
+    };
+
+    for (int i = 0; i < (int)app.timers.size(); ++i) {
+        const auto& timer = app.timers[i];
+        bool expired = timer.t.expired(now);
+        auto shown = timer.t.touched() ? timer.t.remaining(now) : timer.dur;
+        double progress = 0.0;
+        auto total = duration_cast<microseconds>(timer.dur).count();
+        auto rem = duration_cast<microseconds>(timer.t.remaining(now)).count();
+        if (timer.t.touched() && total > 0) progress = std::clamp((double)(total - rem) / (double)total, 0.0, 1.0);
+        auto label = timer.label.empty() ? std::string{"Timer "} + std::to_string(i + 1) : wide_to_utf8(timer.label);
+        state.timers.push_back(TimerSceneState{
+            .running = timer.t.is_running(),
+            .expired = expired,
+            .progress = expired ? 1.0 : progress,
+            .text = wide_to_utf8(format_timer_display(shown)),
+            .label = std::move(label),
+        });
+    }
+    if (state.timers.empty()) state.timers.push_back({});
+    return state;
+}
+
+} // namespace ui_scene

--- a/src/ui_scene.hpp
+++ b/src/ui_scene.hpp
@@ -49,6 +49,12 @@ struct TimerSceneState {
     std::string label = "Timer 1";
 };
 
+struct AlarmSceneState {
+    std::string label;
+    std::string time_text;
+    bool enabled = true;
+};
+
 struct MainSceneState {
     bool topmost = false;
     bool show_clock = true;
@@ -56,9 +62,11 @@ struct MainSceneState {
     bool show_timers = true;
     bool show_alarms = false;
     bool stopwatch_running = false;
+    ClockView clock_view = ClockView::H24_HMS;
     std::string clock_text = "00:00:00";
     std::string stopwatch_text = "00:00.000";
     std::vector<TimerSceneState> timers{{}};
+    std::vector<AlarmSceneState> alarms{};
 };
 
 inline int width(const RectI& r) { return r.right - r.left; }
@@ -148,9 +156,10 @@ inline void add_toolbar(Scene& scene, const Layout& layout, int client_w, const 
 inline void add_clock(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
                       const UiMakers& ui) {
     if (!state.show_clock) return;
+    int h = effective_clk_h(layout, state.clock_view);
     add_divider(scene, 0, client_w, y, ui.divider());
-    add_text(scene, {0, y, client_w, y + layout.clk_h}, state.clock_text, ui.text(), Align::Center, A_CLK_CYCLE);
-    y += layout.clk_h;
+    add_text(scene, {0, y, client_w, y + h}, state.clock_text, ui.text(), Align::Center, A_CLK_CYCLE);
+    y += h;
 }
 
 inline void add_stopwatch(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
@@ -205,10 +214,46 @@ inline void add_timer(Scene& scene, const Layout& layout, int client_w, int& y, 
 
 inline int main_scene_height(const Layout& layout, const MainSceneState& state) {
     int h = layout.bar_h;
-    if (state.show_clock) h += layout.clk_h;
+    if (state.show_clock) h += effective_clk_h(layout, state.clock_view);
     if (state.show_stopwatch) h += layout.sw_h;
     if (state.show_timers) h += (int)state.timers.size() * layout.tmr_h;
+    if (state.show_alarms)
+        h += layout.alarm_header_h + std::max(1, (int)state.alarms.size()) * layout.alarm_row_h;
     return h;
+}
+
+inline void add_alarms(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
+                       const UiMakers& ui) {
+    if (!state.show_alarms) return;
+    add_divider(scene, 0, client_w, y, ui.divider());
+    int header_bottom = y + layout.alarm_header_h;
+    add_text(scene, {0, y, client_w / 2, header_bottom}, "Alarms", ui.text(), Align::Left);
+    int bw = layout.dpi_scale(40);
+    add_button(scene, {client_w - bw - layout.dpi_scale(4), y + layout.dpi_scale(7), client_w - layout.dpi_scale(4),
+                       header_bottom - layout.dpi_scale(7)},
+               "Add", ui.button(ButtonConfig{.radius_px = layout.dpi_scale(4)}), A_ALARM_ADD);
+    y = header_bottom;
+    if (state.alarms.empty()) {
+        add_text(scene, {0, y, client_w, y + layout.alarm_row_h}, "No alarms", ui.text(TextConfig{.tone = TextTone::Dim}),
+                 Align::Center);
+        y += layout.alarm_row_h;
+    } else {
+        for (int i = 0; i < (int)state.alarms.size(); ++i) {
+            const auto& alarm = state.alarms[i];
+            int row_bottom = y + layout.alarm_row_h;
+            add_text(scene, {layout.dpi_scale(4), y, client_w / 2, row_bottom}, alarm.time_text, ui.text(), Align::Left);
+            add_text(scene, {client_w / 2, y, client_w - bw - layout.dpi_scale(8), row_bottom},
+                     alarm.label.empty() ? "Alarm" : alarm.label,
+                     ui.text(alarm.enabled ? TextConfig{} : TextConfig{.tone = TextTone::Dim}), Align::Left);
+            add_button(scene,
+                       {client_w - bw - layout.dpi_scale(4), y + layout.dpi_scale(4), client_w - layout.dpi_scale(4),
+                        row_bottom - layout.dpi_scale(4)},
+                       alarm.enabled ? "On" : "Off",
+                       ui.button(ButtonConfig{.active = alarm.enabled, .radius_px = layout.dpi_scale(4)}),
+                       A_ALARM_TOGGLE + i);
+            y = row_bottom;
+        }
+    }
 }
 
 inline Scene build_main_scene(const Layout& layout, int client_w, const MainSceneState& state, const UiMakers& ui) {
@@ -222,6 +267,7 @@ inline Scene build_main_scene(const Layout& layout, int client_w, const MainScen
         for (int i = 0; i < (int)state.timers.size(); ++i)
             add_timer(scene, layout, client_w, y, i, state.timers[i], ui);
     }
+    add_alarms(scene, layout, client_w, y, state, ui);
     return scene;
 }
 
@@ -246,10 +292,22 @@ inline MainSceneState main_scene_state_from_app(const App& app, std::chrono::ste
         .show_timers = app.show_tmr,
         .show_alarms = app.show_alarms,
         .stopwatch_running = app.sw.is_running(),
+        .clock_view = app.clock_view,
         .clock_text = std::move(clock_text),
         .stopwatch_text = wide_to_utf8(format_stopwatch_display(app.sw.elapsed(now))),
         .timers = {},
+        .alarms = {},
     };
+
+    for (const auto& alarm : app.alarms) {
+        char buf[8] = {};
+        std::snprintf(buf, sizeof(buf), "%02d:%02d", alarm.hour, alarm.minute);
+        state.alarms.push_back(AlarmSceneState{
+            .label = alarm.name,
+            .time_text = buf,
+            .enabled = alarm.enabled,
+        });
+    }
 
     for (int i = 0; i < (int)app.timers.size(); ++i) {
         const auto& timer = app.timers[i];

--- a/src/ui_style.hpp
+++ b/src/ui_style.hpp
@@ -1,0 +1,294 @@
+#pragma once
+#include <cstdint>
+#include <optional>
+
+#include "config.hpp"
+
+struct UiColor {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+};
+
+constexpr UiColor rgb(std::uint8_t r, std::uint8_t g, std::uint8_t b) { return UiColor{r, g, b}; }
+
+struct ThemePalette {
+    UiColor bg;
+    UiColor bar;
+    UiColor btn;
+    UiColor active;
+    UiColor text;
+    UiColor dim;
+    UiColor warn;
+    UiColor expire;
+    UiColor blink;
+    UiColor fill;
+    UiColor fill_exp;
+    UiColor help_bg;
+    UiColor divider;
+};
+
+constexpr ThemePalette dark_palette{
+    .bg = rgb(26, 26, 26),
+    .bar = rgb(35, 35, 38),
+    .btn = rgb(40, 40, 44),
+    .active = rgb(80, 80, 88),
+    .text = rgb(204, 204, 204),
+    .dim = rgb(90, 90, 90),
+    .warn = rgb(240, 140, 30),
+    .expire = rgb(200, 50, 50),
+    .blink = rgb(110, 110, 118),
+    .fill = rgb(38, 38, 50),
+    .fill_exp = rgb(72, 18, 18),
+    .help_bg = rgb(20, 20, 20),
+    .divider = rgb(50, 50, 55),
+};
+
+constexpr ThemePalette light_palette{
+    .bg = rgb(243, 243, 243),
+    .bar = rgb(228, 228, 232),
+    .btn = rgb(214, 214, 220),
+    .active = rgb(175, 175, 188),
+    .text = rgb(28, 28, 28),
+    .dim = rgb(138, 138, 138),
+    .warn = rgb(196, 90, 0),
+    .expire = rgb(196, 36, 36),
+    .blink = rgb(168, 168, 178),
+    .fill = rgb(208, 208, 230),
+    .fill_exp = rgb(240, 196, 196),
+    .help_bg = rgb(232, 232, 232),
+    .divider = rgb(198, 198, 208),
+};
+
+constexpr const ThemePalette& palette_for(ThemeMode mode, bool system_dark) {
+    return mode == ThemeMode::Dark || (mode == ThemeMode::Auto && system_dark) ? dark_palette : light_palette;
+}
+
+struct UiStyleConfig {
+    ThemeMode theme_mode = ThemeMode::Auto;
+    bool system_dark = true;
+};
+
+constexpr const ThemePalette& palette_for(const UiStyleConfig& config) {
+    return palette_for(config.theme_mode, config.system_dark);
+}
+
+struct SurfaceConfig {
+    bool elevated = false;
+};
+
+struct DialogConfig {
+    bool active = true;
+    bool scrollable = false;
+};
+
+struct ScrollViewConfig {
+    bool enabled = false;
+};
+
+struct ButtonConfig {
+    bool active = false;
+    bool focused = false;
+    bool blinking = false;
+    std::optional<UiColor> fill_override = std::nullopt;
+    int radius_px = 6;
+};
+
+struct DropdownConfig {
+    bool open = false;
+    bool focused = false;
+    int radius_px = 4;
+};
+
+struct ToggleConfig {
+    bool on = false;
+    bool focused = false;
+    int radius_px = 4;
+};
+
+struct ProgressConfig {
+    bool expired = false;
+};
+
+struct AnalogClockConfig {
+    bool selected = false;
+};
+
+struct IconConfig {
+    bool active = false;
+};
+
+enum class TextTone { Primary, Dim, Warning, Danger };
+
+struct TextConfig {
+    TextTone tone = TextTone::Primary;
+};
+
+struct SurfacePaint {
+    UiColor background;
+    UiColor border;
+};
+
+struct DialogPaint {
+    UiColor background;
+    UiColor title_text;
+    UiColor divider;
+    UiColor content_background;
+};
+
+struct ScrollViewPaint {
+    UiColor track;
+    UiColor thumb;
+    UiColor divider;
+};
+
+struct WidgetPaint {
+    UiColor fill;
+    UiColor text;
+    UiColor border;
+    int radius_px;
+};
+
+struct TextPaint {
+    UiColor color;
+};
+
+struct DividerPaint {
+    UiColor color;
+};
+
+struct ProgressPaint {
+    UiColor fill;
+};
+
+struct AnalogClockPaint {
+    UiColor background;
+    UiColor face;
+    UiColor outline;
+    UiColor tick;
+    UiColor text;
+    UiColor accent;
+};
+
+struct IconPaint {
+    UiColor background;
+    UiColor foreground;
+    UiColor accent;
+};
+
+struct UiMakers {
+    ThemePalette palette;
+
+    constexpr SurfacePaint surface(SurfaceConfig config = {}) const {
+        return SurfacePaint{
+            .background = config.elevated ? palette.bar : palette.bg,
+            .border = palette.divider,
+        };
+    }
+
+    constexpr DialogPaint dialog(DialogConfig = {}) const {
+        return DialogPaint{
+            .background = palette.bg,
+            .title_text = palette.text,
+            .divider = palette.divider,
+            .content_background = palette.bg,
+        };
+    }
+
+    constexpr ScrollViewPaint scroll_view(ScrollViewConfig config = {}) const {
+        return ScrollViewPaint{
+            .track = palette.bar,
+            .thumb = config.enabled ? palette.active : palette.dim,
+            .divider = palette.divider,
+        };
+    }
+
+    constexpr WidgetPaint button(ButtonConfig config = {}) const {
+        return WidgetPaint{
+            .fill = config.blinking        ? palette.blink
+                    : config.fill_override ? *config.fill_override
+                    : config.active        ? palette.active
+                                           : palette.btn,
+            .text = palette.text,
+            .border = config.focused ? palette.text : palette.divider,
+            .radius_px = config.radius_px,
+        };
+    }
+
+    constexpr WidgetPaint dropdown(DropdownConfig config = {}) const {
+        return WidgetPaint{
+            .fill = config.open ? palette.active : palette.btn,
+            .text = palette.text,
+            .border = config.focused ? palette.text : palette.divider,
+            .radius_px = config.radius_px,
+        };
+    }
+
+    constexpr WidgetPaint toggle(ToggleConfig config = {}) const {
+        return WidgetPaint{
+            .fill = config.on ? palette.active : palette.btn,
+            .text = palette.text,
+            .border = config.focused ? palette.text : palette.divider,
+            .radius_px = config.radius_px,
+        };
+    }
+
+    constexpr TextPaint text(TextConfig config = {}) const {
+        return TextPaint{.color = config.tone == TextTone::Dim       ? palette.dim
+                                  : config.tone == TextTone::Warning ? palette.warn
+                                  : config.tone == TextTone::Danger  ? palette.expire
+                                                                     : palette.text};
+    }
+
+    constexpr DividerPaint divider() const { return DividerPaint{.color = palette.divider}; }
+
+    constexpr ProgressPaint progress(ProgressConfig config = {}) const {
+        return ProgressPaint{.fill = config.expired ? palette.fill_exp : palette.fill};
+    }
+
+    constexpr AnalogClockPaint analog_clock(AnalogClockConfig config = {}) const {
+        return AnalogClockPaint{
+            .background = palette.bg,
+            .face = palette.fill,
+            .outline = config.selected ? palette.active : palette.divider,
+            .tick = palette.dim,
+            .text = palette.text,
+            .accent = palette.warn,
+        };
+    }
+
+    constexpr IconPaint icon(IconConfig config = {}) const {
+        return IconPaint{
+            .background = config.active ? palette.active : palette.bg,
+            .foreground = palette.text,
+            .accent = palette.warn,
+        };
+    }
+};
+
+constexpr UiMakers make_ui(const ThemePalette& palette) { return UiMakers{.palette = palette}; }
+constexpr UiMakers make_ui(UiStyleConfig config) { return make_ui(palette_for(config)); }
+
+constexpr DialogPaint make_dialog(const ThemePalette& palette, const DialogConfig& config) {
+    return make_ui(palette).dialog(config);
+}
+
+constexpr ScrollViewPaint make_scrollable_view(const ThemePalette& palette, const ScrollViewConfig& config) {
+    return make_ui(palette).scroll_view(config);
+}
+
+constexpr AnalogClockPaint make_analog_clock(const ThemePalette& palette, const AnalogClockConfig& config) {
+    return make_ui(palette).analog_clock(config);
+}
+
+constexpr IconPaint make_icon(const ThemePalette& palette, const IconConfig& config) {
+    return make_ui(palette).icon(config);
+}
+
+constexpr WidgetPaint make_button(const ThemePalette& palette, const ButtonConfig& config) {
+    return make_ui(palette).button(config);
+}
+
+constexpr WidgetPaint make_dropdown(const ThemePalette& palette, const DropdownConfig& config) {
+    return make_ui(palette).dropdown(config);
+}

--- a/src/ui_windows_painter.hpp
+++ b/src/ui_windows_painter.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <windows.h>
+
+#include "gdi.hpp"
+#include "theme.hpp"
+#include "ui_style.hpp"
+
+inline GdiObj win_brush(UiColor color) { return GdiObj{CreateSolidBrush(colorref_from_ui(color))}; }
+
+inline GdiObj win_pen(UiColor color, int width = 1, int style = PS_SOLID) {
+    return GdiObj{CreatePen(style, width, colorref_from_ui(color))};
+}
+
+inline void win_fill_rect(HDC hdc, const RECT& rc, UiColor color) {
+    GdiObj brush = win_brush(color);
+    FillRect(hdc, &rc, (HBRUSH)brush.h);
+}
+
+inline void win_paint_text(HDC hdc, const RECT& rc, const wchar_t* text, HFONT font, const TextPaint& paint,
+                           UINT format = DT_LEFT | DT_VCENTER | DT_SINGLELINE) {
+    SetBkMode(hdc, TRANSPARENT);
+    SetTextColor(hdc, colorref_from_ui(paint.color));
+    if (font) SelectObject(hdc, font);
+    RECT text_rc = rc;
+    DrawTextW(hdc, text, -1, &text_rc, format);
+}
+
+inline void win_paint_label(HDC hdc, const RECT& rc, const wchar_t* text, HFONT font, const ThemePalette& palette,
+                            UINT format = DT_LEFT | DT_VCENTER | DT_SINGLELINE) {
+    win_paint_text(hdc, rc, text, font, make_ui(palette).text(), format);
+}
+
+inline void win_paint_divider(HDC hdc, int x0, int x1, int y, const DividerPaint& paint) {
+    GdiObj pen = win_pen(paint.color);
+    auto* old_pen = (HPEN)SelectObject(hdc, pen.h);
+    MoveToEx(hdc, x0, y, nullptr);
+    LineTo(hdc, x1, y);
+    SelectObject(hdc, old_pen);
+}
+
+inline void win_paint_progress(HDC hdc, const RECT& rc, const ProgressPaint& paint) {
+    win_fill_rect(hdc, rc, paint.fill);
+}
+
+inline void win_paint_button(HDC hdc, const RECT& rc, const wchar_t* text, HFONT font, const WidgetPaint& paint,
+                             UINT text_format = DT_CENTER | DT_VCENTER | DT_SINGLELINE) {
+    GdiObj brush = win_brush(paint.fill);
+    GdiObj pen = win_pen(paint.border);
+    auto* old_brush = (HBRUSH)SelectObject(hdc, brush.h);
+    auto* old_pen = (HPEN)SelectObject(hdc, pen.h);
+    RoundRect(hdc, rc.left, rc.top, rc.right, rc.bottom, paint.radius_px, paint.radius_px);
+    SelectObject(hdc, old_brush);
+    SelectObject(hdc, old_pen);
+
+    win_paint_text(hdc, rc, text, font, TextPaint{.color = paint.text}, text_format);
+}

--- a/src/ui_windows_settings_dialog.cpp
+++ b/src/ui_windows_settings_dialog.cpp
@@ -3,11 +3,13 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <algorithm>
+#include <array>
 #include <format>
 #include <vector>
 #include "app.hpp"
 #include "dialog_style.hpp"
 #include "painting_analog.hpp"
+#include "ui_windows_painter.hpp"
 
 namespace ui {
 
@@ -170,8 +172,54 @@ static RECT map_dlu(HWND dlg, short x, short y, short cx, short cy) {
     return r;
 }
 
-constexpr int ANALOG_COLOR_COUNT = 9;
-constexpr int ANALOG_VALUE_COUNT = 15;
+// Keep each owner-drawn analog setting as data: the label, backing field,
+// and (for numeric values) valid stepping range live together. Paint,
+// hit-testing, and mutation then iterate the same source of truth.
+struct AnalogColorOption {
+    const wchar_t* label;
+    int AnalogClockStyle::*field;
+};
+
+struct AnalogValueOption {
+    const wchar_t* label;
+    int AnalogClockStyle::*field;
+    int min_value;
+    int max_value;
+    int step;
+};
+
+static constexpr std::array<AnalogColorOption, 9> kAnalogColors{{
+    {L"Hour", &AnalogClockStyle::hour_color},
+    {L"Minute", &AnalogClockStyle::minute_color},
+    {L"Second", &AnalogClockStyle::second_color},
+    {L"Background", &AnalogClockStyle::background_color},
+    {L"Face fill", &AnalogClockStyle::face_fill_color},
+    {L"Outline", &AnalogClockStyle::face_outline_color},
+    {L"Ticks", &AnalogClockStyle::tick_color},
+    {L"Numbers", &AnalogClockStyle::hour_label_color},
+    {L"Center dot", &AnalogClockStyle::center_dot_color},
+}};
+
+static constexpr std::array<AnalogValueOption, 15> kAnalogValues{{
+    {L"Hour length", &AnalogClockStyle::hour_len_pct, 0, 100, 5},
+    {L"Minute length", &AnalogClockStyle::minute_len_pct, 0, 100, 5},
+    {L"Second length", &AnalogClockStyle::second_len_pct, 0, 100, 5},
+    {L"Hour thickness", &AnalogClockStyle::hour_thickness, 1, 6, 1},
+    {L"Minute thickness", &AnalogClockStyle::minute_thickness, 1, 4, 1},
+    {L"Second thickness", &AnalogClockStyle::second_thickness, 1, 3, 1},
+    {L"Hour tick", &AnalogClockStyle::hour_tick_pct, 5, 20, 1},
+    {L"Minute tick", &AnalogClockStyle::minute_tick_pct, 2, 10, 1},
+    {L"Center dot", &AnalogClockStyle::center_dot_size, 0, 10, 1},
+    {L"Hour opacity", &AnalogClockStyle::hour_opacity_pct, 10, 100, 10},
+    {L"Minute opacity", &AnalogClockStyle::minute_opacity_pct, 10, 100, 10},
+    {L"Second opacity", &AnalogClockStyle::second_opacity_pct, 10, 100, 10},
+    {L"Tick opacity", &AnalogClockStyle::tick_opacity_pct, 10, 100, 10},
+    {L"Face opacity", &AnalogClockStyle::face_opacity_pct, 0, 100, 10},
+    {L"Clock radius", &AnalogClockStyle::radius_pct, 50, 100, 5},
+}};
+
+constexpr int ANALOG_COLOR_COUNT = static_cast<int>(kAnalogColors.size());
+constexpr int ANALOG_VALUE_COUNT = static_cast<int>(kAnalogValues.size());
 
 struct HitRects {
     RECT sidebar[TAB_COUNT];
@@ -381,21 +429,11 @@ static void apply_scroll(HWND dlg, Params* p, int new_pos) {
 
 static void paint_option_btn(HDC hdc, const RECT& rc, const wchar_t* text, bool selected,
                               const DlgStyle& s) {
-    int rr = s.scale(4);
-    HBRUSH br = CreateSolidBrush(selected ? s.theme->active : s.theme->btn);
-    HPEN pen = CreatePen(PS_NULL, 0, 0);
-    auto* obr = (HBRUSH)SelectObject(hdc, br);
-    auto* opn = (HPEN)SelectObject(hdc, pen);
-    RoundRect(hdc, rc.left, rc.top, rc.right, rc.bottom, rr, rr);
-    SelectObject(hdc, obr);
-    SelectObject(hdc, opn);
-    DeleteObject(br);
-    DeleteObject(pen);
-    SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, s.theme->text);
-    SelectObject(hdc, s.font);
-    RECT r = rc;
-    DrawTextW(hdc, text, -1, &r, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    WidgetPaint button = make_button(s.theme->palette, ButtonConfig{
+                                                           .active = selected,
+                                                           .radius_px = s.scale(4),
+                                                       });
+    win_paint_button(hdc, rc, text, s.font, button);
 }
 
 static bool read_field(HWND dlg, int id, int& out) {
@@ -485,72 +523,23 @@ static void set_initial_tab_visibility(HWND dlg, Params& p) {
 }
 
 static int* analog_color_field(AnalogClockStyle& a, int i) {
-    switch (i) {
-    case 0: return &a.hour_color;
-    case 1: return &a.minute_color;
-    case 2: return &a.second_color;
-    case 3: return &a.background_color;
-    case 4: return &a.face_fill_color;
-    case 5: return &a.face_outline_color;
-    case 6: return &a.tick_color;
-    case 7: return &a.hour_label_color;
-    case 8: return &a.center_dot_color;
-    default: return nullptr;
-    }
+    if (i < 0 || i >= ANALOG_COLOR_COUNT) return nullptr;
+    return &(a.*kAnalogColors[(size_t)i].field);
 }
 
 static int* analog_value_field(AnalogClockStyle& a, int i) {
-    switch (i) {
-    case 0: return &a.hour_len_pct;
-    case 1: return &a.minute_len_pct;
-    case 2: return &a.second_len_pct;
-    case 3: return &a.hour_thickness;
-    case 4: return &a.minute_thickness;
-    case 5: return &a.second_thickness;
-    case 6: return &a.hour_tick_pct;
-    case 7: return &a.minute_tick_pct;
-    case 8: return &a.center_dot_size;
-    case 9: return &a.hour_opacity_pct;
-    case 10: return &a.minute_opacity_pct;
-    case 11: return &a.second_opacity_pct;
-    case 12: return &a.tick_opacity_pct;
-    case 13: return &a.face_opacity_pct;
-    case 14: return &a.radius_pct;
-    default: return nullptr;
-    }
+    if (i < 0 || i >= ANALOG_VALUE_COUNT) return nullptr;
+    return &(a.*kAnalogValues[(size_t)i].field);
 }
 
-static void analog_value_range(int i, int& min_v, int& max_v, int& step) {
-    struct Range { int min_v, max_v, step; };
-    static constexpr Range ranges[ANALOG_VALUE_COUNT] = {
-        {0, 100, 5}, {0, 100, 5}, {0, 100, 5},
-        {1, 6, 1}, {1, 4, 1}, {1, 3, 1},
-        {5, 20, 1}, {2, 10, 1}, {0, 10, 1},
-        {10, 100, 10}, {10, 100, 10}, {10, 100, 10},
-        {10, 100, 10}, {0, 100, 10}, {50, 100, 5},
-    };
-    min_v = ranges[i].min_v;
-    max_v = ranges[i].max_v;
-    step = ranges[i].step;
-}
+static void adjust_analog_value(AnalogClockStyle& a, int i, int direction) {
+    int* field = analog_value_field(a, i);
+    if (!field) return;
 
-static const wchar_t* analog_color_label(int i) {
-    static constexpr const wchar_t* labels[ANALOG_COLOR_COUNT] = {
-        L"Hour", L"Minute", L"Second", L"Background", L"Face fill",
-        L"Outline", L"Ticks", L"Numbers", L"Center dot"
-    };
-    return labels[i];
-}
-
-static const wchar_t* analog_value_label(int i) {
-    static constexpr const wchar_t* labels[ANALOG_VALUE_COUNT] = {
-        L"Hour length", L"Minute length", L"Second length",
-        L"Hour thickness", L"Minute thickness", L"Second thickness",
-        L"Hour tick", L"Minute tick", L"Center dot",
-        L"Hour opacity", L"Minute opacity", L"Second opacity",
-        L"Tick opacity", L"Face opacity", L"Clock radius"
-    };
-    return labels[i];
+    const auto& option = kAnalogValues[(size_t)i];
+    *field += option.step * direction;
+    if (*field > option.max_value) *field = option.min_value;
+    if (*field < option.min_value) *field = option.max_value;
 }
 
 static constexpr COLORREF ANALOG_PALETTE_COLORS[] = {
@@ -742,7 +731,7 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
                     r.top += sdy; r.bottom += sdy;
                     int* field = analog_color_field(p->analog_style, i);
                     bool custom = field && *field >= 0;
-                    paint_option_btn(hdc, r, analog_color_label(i), custom, s);
+                    paint_option_btn(hdc, r, kAnalogColors[(size_t)i].label, custom, s);
                     RECT sw = {r.right - s.scale(14), r.top + s.scale(2), r.right - s.scale(3), r.bottom - s.scale(2)};
                     COLORREF sw_color = custom ? (COLORREF)*field : s.theme->dim;
                     GdiObj br{CreateSolidBrush(sw_color)};
@@ -757,7 +746,7 @@ static INT_PTR on_erase_background(HWND dlg, HDC hdc) {
                     r.top += sdy; r.bottom += sdy;
                     int* field = analog_value_field(p->analog_style, i);
                     wchar_t buf[96];
-                    wsprintfW(buf, L"%s: %d", analog_value_label(i), field ? *field : 0);
+                    wsprintfW(buf, L"%s: %d", kAnalogValues[(size_t)i].label, field ? *field : 0);
                     paint_option_btn(hdc, r, buf, false, s);
                 }
 
@@ -865,15 +854,9 @@ static INT_PTR on_left_button_down(HWND dlg, LPARAM lp) {
         }
         for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
             if (PtInRect(&p->rects.analog_values[i], spt)) {
-                int* field = analog_value_field(p->analog_style, i);
-                if (field) {
-                    int min_v, max_v, step;
-                    analog_value_range(i, min_v, max_v, step);
-                    *field += step;
-                    if (*field > max_v) *field = min_v;
-                    InvalidateRect(dlg, nullptr, TRUE);
-                    return TRUE;
-                }
+                adjust_analog_value(p->analog_style, i, 1);
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
             }
         }
     }
@@ -1054,15 +1037,9 @@ static INT_PTR on_right_button_down(HWND dlg, LPARAM lp) {
     }
     for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
         if (PtInRect(&p->rects.analog_values[i], spt)) {
-            int* field = analog_value_field(p->analog_style, i);
-            if (field) {
-                int min_v, max_v, step;
-                analog_value_range(i, min_v, max_v, step);
-                *field -= step;
-                if (*field < min_v) *field = max_v;
-                InvalidateRect(dlg, nullptr, TRUE);
-                return TRUE;
-            }
+            adjust_analog_value(p->analog_style, i, -1);
+            InvalidateRect(dlg, nullptr, TRUE);
+            return TRUE;
         }
     }
     return FALSE;

--- a/src/wndstate.hpp
+++ b/src/wndstate.hpp
@@ -115,8 +115,12 @@ inline void recreate_fonts(WndState& s) {
 }
 
 inline void apply_theme(HWND hwnd, WndState& s) {
-    bool dark = (s.app.theme_mode == ThemeMode::Dark) ||
-                (s.app.theme_mode == ThemeMode::Auto && system_prefers_dark());
+    UiStyleConfig style_config{
+        .theme_mode = s.app.theme_mode,
+        .system_dark = system_prefers_dark(),
+    };
+    const ThemePalette& palette = palette_for(style_config);
+    bool dark = &palette == &dark_palette;
     BOOL dwm_dark = dark ? TRUE : FALSE;
     DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_ATTR, &dwm_dark, sizeof(dwm_dark));
     s.active_theme = dark ? &dark_theme : &light_theme;


### PR DESCRIPTION
### Motivation

- Separate platform‑neutral UI recipes and scene construction from platform rendering so the same widget semantics can be painted by Win32/GDI or an X11 adapter. 
- Move color palettes and widget recipes out of Windows‑specific code to enable a portable rendering target and easier Linux UI progress. 
- Reduce duplication in CMake lists and expose a logic‑portable `chronos_core` target so tests and the app share the same sources. 

### Description

- Add `src/ui_style.hpp` to define `ThemePalette`, `UiMakers`, paint structs (`WidgetPaint`, `TextPaint`, `ProgressPaint`, etc.) and helper makers (`make_ui`, `make_button`, etc.).
- Add `src/ui_scene.hpp` to build a platform‑neutral `Scene` for the main app surface with hit testing and a `main_scene_state_from_app` adapter. 
- Add `src/ui_windows_painter.hpp` to convert `Ui*` paint types to GDI objects and provide `win_paint_*` helpers used across dialogs and painters. 
- Rework rendering pipeline to use the new style/scene APIs: updates in `paint_ctx.hpp`, `painting_timer.cpp`, `painting_analog.cpp`, `dialog_style.cpp`, `alarm_dialog.cpp`, `ui_windows_settings_dialog.cpp`, `icon.hpp`, and `wndstate.hpp` to use `UiMakers`/paints and the Windows painter helpers. 
- Implement an X11 scene renderer and interaction glue in `src/ui_linux.cpp` to drive the same `App` state and dispatch actions using `ui_scene` ops and hit testing. 
- Update `src/theme.hpp` to map `ThemePalette` → `Theme` via `make_theme` and add conversion helpers between `UiColor` and `COLORREF`. 
- Update project files and documentation: add `ARCHITECTURE.md` UI inventory text, update `README.md` to describe the X11 adapter approach, and add new source files to the tree. 
- Restructure `CMakeLists.txt` to introduce an interface target `chronos_project_options`, a static `chronos_core` library for logic‑portable sources, helper `chronos_use_lld` for optional LLD linking, and link tests and app against `chronos_core`.

### Testing

- Ran CMake configure and built the test preset (`cmake --preset test` and `cmake --build build`) successfully. 
- Built and executed the unit test suite (`./build/chronos_tests`) and all Catch2 tests passed. 
- Verified CMake changes produce `chronos_core` and that tests link against the core target successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07acf4ec4c832caa791046683c711d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform‑neutral UI styling with selectable palettes and consistent widget paints.
  * Scene‑based renderer on Linux with richer interactive layouts, hit‑tested controls, and centralized input handling.
  * Themed OS painting for consistent buttons, dividers, progress, text, and analog clock visuals.

* **Refactor**
  * Shared core module and unified build options; UI now driven by high‑level style/paint factories and data‑driven dialogs/settings.

* **Documentation**
  * Architecture and platform notes expanded to describe UI surfaces, styling, and migration direction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->