### PR TITLE
Add inline editing for analog clock value settings

### DIFF
--- a/src/core/config_serial.cpp
+++ b/src/core/config_serial.cpp
@@ -53,7 +53,7 @@ constexpr std::array<AnalogInt, 25> kAnalogInts = {{
     {"analog_second_opacity",     &AnalogClockStyle::second_opacity_pct, 10,  100},
     {"analog_tick_opacity",       &AnalogClockStyle::tick_opacity_pct,   10,  100},
     {"analog_face_opacity",       &AnalogClockStyle::face_opacity_pct,    0,  100},
-    {"analog_radius",             &AnalogClockStyle::radius_pct,         50,  100},
+    {"analog_radius",             &AnalogClockStyle::radius_pct,         50,  500},
 }};
 // hour_labels (enum) and show_minute_ticks (bool) handled inline.
 

--- a/src/input/input_core.cpp
+++ b/src/input/input_core.cpp
@@ -60,9 +60,12 @@ void handle(HWND hwnd, int act, WndState& s) {
     if (r.open_settings) {
         auto old_theme = s.app.theme_mode;
         auto old_clock = s.app.clock_view;
+        int old_radius = s.app.analog_style.radius_pct;
         if (ui::show_settings_dialog(hwnd, s.app, (ui::FontHandle)s.fontSm.h, s.active_theme, s.layout.dpi)) {
             if (s.app.theme_mode != old_theme) apply_theme(hwnd, s);
-            if (s.app.clock_view != old_clock) resize_window(hwnd, s);
+            if (s.app.clock_view != old_clock ||
+                s.app.analog_style.radius_pct != old_radius)
+                resize_window(hwnd, s);
             save_config(hwnd, s);
         }
     }

--- a/src/painting/painting_analog.cpp
+++ b/src/painting/painting_analog.cpp
@@ -53,6 +53,8 @@ void draw_analog_clock_native(HDC hdc, RECT area, const AnalogClockStyle& style,
     int w = area.right - area.left;
     int h = area.bottom - area.top;
     int radius = (w < h ? w : h) / 2 - dpi * 6 / STANDARD_DPI;
+    // Above 100 the analog area itself has already been scaled (see
+    // effective_clk_h), so the paint-side scale tops out at 100% of that area.
     radius = radius * std::clamp(style.radius_pct, 50, 100) / 100;
     if (radius < 10) return;
 

--- a/src/ui/layout.hpp
+++ b/src/ui/layout.hpp
@@ -76,6 +76,8 @@ struct LayoutState {
     int timer_count = 1;
     int alarm_count = 0;
     ClockView clock_view = ClockView::H24_HMS;
+    // Drives analog-clock height growth past 100% (see effective_clk_h).
+    int analog_radius_pct = 100;
 };
 
 struct TimerMetrics {
@@ -102,13 +104,18 @@ struct TimerMetrics {
     }
 };
 
-inline int effective_clk_h(const Layout& layout, ClockView view) {
-    return view == ClockView::Analog ? layout.analog_clk_h : layout.clk_h;
+// Analog clock height scales linearly past 100%: the drawing area grows to
+// accommodate radius_pct > 100 while painting itself stays clamped to the
+// area. Digital views ignore radius_pct.
+inline int effective_clk_h(const Layout& layout, ClockView view, int analog_radius_pct = 100) {
+    if (view != ClockView::Analog) return layout.clk_h;
+    int scale = analog_radius_pct < 100 ? 100 : analog_radius_pct;
+    return layout.analog_clk_h * scale / 100;
 }
 
 inline int client_height_for(const Layout& layout, const LayoutState& state) {
     int h = layout.bar_h;
-    if (state.show_clk) h += effective_clk_h(layout, state.clock_view);
+    if (state.show_clk) h += effective_clk_h(layout, state.clock_view, state.analog_radius_pct);
     if (state.show_sw) h += layout.sw_h;
     if (state.show_tmr) h += state.timer_count * layout.tmr_h;
     if (state.show_alarms) h += layout.alarm_header_h + (state.alarm_count > 0 ? state.alarm_count : 1) * layout.alarm_row_h;
@@ -118,7 +125,7 @@ inline int client_height_for(const Layout& layout, const LayoutState& state) {
 inline int timer_index_at_y(const Layout& layout, const LayoutState& state, int y) {
     if (!state.show_tmr) return -1;
     int top = layout.bar_h;
-    if (state.show_clk) top += effective_clk_h(layout, state.clock_view);
+    if (state.show_clk) top += effective_clk_h(layout, state.clock_view, state.analog_radius_pct);
     if (state.show_sw) top += layout.sw_h;
     if (y < top) return -1;
     int idx = (y - top) / layout.tmr_h;

--- a/src/ui/ui_scene.hpp
+++ b/src/ui/ui_scene.hpp
@@ -220,7 +220,7 @@ inline void add_toolbar(Scene& scene, const Layout& layout, int client_w, const 
 inline void add_clock(Scene& scene, const Layout& layout, int client_w, int& y, const MainSceneState& state,
                       const UiMakers& ui) {
     if (!state.show_clock) return;
-    int h = effective_clk_h(layout, state.clock_view);
+    int h = effective_clk_h(layout, state.clock_view, state.analog_style.radius_pct);
     add_divider(scene, 0, client_w, y, ui.divider());
     if (state.clock_view == ClockView::Analog) {
         scene.analog_clock = AnalogClockOp{
@@ -402,7 +402,7 @@ inline void add_help_overlay(Scene& scene, const Layout& layout, int client_w, i
 
 inline int main_scene_height(const Layout& layout, const MainSceneState& state) {
     int h = layout.bar_h;
-    if (state.show_clock) h += effective_clk_h(layout, state.clock_view);
+    if (state.show_clock) h += effective_clk_h(layout, state.clock_view, state.analog_style.radius_pct);
     if (state.show_stopwatch) h += layout.sw_h;
     if (state.show_timers) h += (int)state.timers.size() * layout.tmr_h;
     if (state.show_alarms)

--- a/src/win32/geometry.hpp
+++ b/src/win32/geometry.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <windows.h>
 #include "layout.hpp"
 #include "wndstate.hpp"
@@ -12,6 +13,7 @@ inline LayoutState layout_state(const WndState& s) {
         .timer_count = (int)s.app.timers.size(),
         .alarm_count = (int)s.app.alarms.size(),
         .clock_view = s.app.clock_view,
+        .analog_radius_pct = s.app.analog_style.radius_pct,
     };
 }
 
@@ -24,9 +26,27 @@ inline int nonclient_height(HWND hwnd) {
     return (wr.bottom - wr.top) - cr.bottom;
 }
 
+// For an oversized analog clock, the painted radius is bounded by min(w,h)/2,
+// so leaving the window at its current width would cap visible growth. Pick a
+// width that lets the clock actually reach the requested radius_pct.
+inline int min_client_w_for(const WndState& s) {
+    int w = s.layout.bar_min_client_w();
+    if (s.app.show_clk && s.app.clock_view == ClockView::Analog &&
+        s.app.analog_style.radius_pct > 100) {
+        int analog_h = effective_clk_h(s.layout, ClockView::Analog, s.app.analog_style.radius_pct);
+        w = std::max(w, analog_h);
+    }
+    return w;
+}
+
 inline void resize_window(HWND hwnd, const WndState& s) {
     RECT wr;
     GetWindowRect(hwnd, &wr);
     int cur_w = wr.right - wr.left;
-    SetWindowPos(hwnd, nullptr, 0, 0, cur_w, client_height(s) + nonclient_height(hwnd), SWP_NOMOVE | SWP_NOZORDER);
+    RECT cr;
+    GetClientRect(hwnd, &cr);
+    int nonclient_w = cur_w - cr.right;
+    int min_w = min_client_w_for(s) + nonclient_w;
+    int new_w = std::max(cur_w, min_w);
+    SetWindowPos(hwnd, nullptr, 0, 0, new_w, client_height(s) + nonclient_height(hwnd), SWP_NOMOVE | SWP_NOZORDER);
 }

--- a/src/win32/ui_windows_settings_dialog.cpp
+++ b/src/win32/ui_windows_settings_dialog.cpp
@@ -299,6 +299,10 @@ static AnalogValueParts split_value_rect(const RECT& r) {
     return parts;
 }
 
+// Forward declarations used before their definitions appear later in the file.
+static Params* dialog_params(HWND dlg);
+static void close_value_edit(HWND dlg, Params& p);
+
 // ─── Scroll & visibility ──────────────────────────────────────────────────────
 
 // Returns the pixel y where the scrollable content area ends (top of button row).
@@ -479,8 +483,6 @@ static bool read_field(HWND dlg, int id, int& out) {
 static Params* dialog_params(HWND dlg) {
     return reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
 }
-
-static void close_value_edit(HWND dlg, Params& p);
 
 static constexpr struct { ThemeMode mode; int id; } kThemeMap[] = {
     {ThemeMode::Auto,  IDC_THEME_AUTO},
@@ -828,7 +830,12 @@ static INT_PTR on_draw_item(HWND dlg, LPARAM lp) {
 static LRESULT CALLBACK value_edit_subclass(HWND edit, UINT msg, WPARAM wp, LPARAM lp) {
     HWND parent = GetParent(edit);
     auto* p = dialog_params(parent);
-    if (!p) return DefWindowProcW(edit, msg, wp, lp);
+    if (!p || !p->orig_value_edit_proc) return DefWindowProcW(edit, msg, wp, lp);
+    if (msg == WM_GETDLGCODE) {
+        // Claim Return/Escape so the dialog manager doesn't forward them to
+        // the Apply/Cancel buttons before our WM_KEYDOWN handler runs.
+        return CallWindowProcW(p->orig_value_edit_proc, edit, msg, wp, lp) | DLGC_WANTALLKEYS;
+    }
     if (msg == WM_KEYDOWN) {
         if (wp == VK_RETURN) {
             SetFocus(parent);
@@ -891,11 +898,16 @@ static bool handle_value_edit_killfocus(HWND dlg, int id, HWND edit, Params& p) 
         if (end && *end == L'\0' && buf[0] != L'\0')
             *field = std::clamp((int)v, opt.min_value, opt.max_value);
     }
+    // Restore the stock EDIT proc before DestroyWindow so the WM_DESTROY /
+    // WM_NCDESTROY messages don't route through value_edit_subclass after we've
+    // already cleared its access to orig_value_edit_proc.
+    if (p.orig_value_edit_proc)
+        SetWindowLongPtrW(edit, GWLP_WNDPROC, (LONG_PTR)p.orig_value_edit_proc);
+    DestroyWindow(edit);
     p.value_edit_cancelled = false;
     p.editing_value_idx = -1;
     p.value_edit = nullptr;
     p.orig_value_edit_proc = nullptr;
-    DestroyWindow(edit);
     InvalidateRect(dlg, nullptr, TRUE);
     return true;
 }

--- a/src/win32/ui_windows_settings_dialog.cpp
+++ b/src/win32/ui_windows_settings_dialog.cpp
@@ -43,6 +43,9 @@ constexpr int IDC_PRESET_MIN3  = 328;
 constexpr int IDC_PRESET_MIN4  = 329;
 constexpr int IDC_CLOCK_COMBO  = 330;
 
+// Inline edits over analog value boxes. One ID per value index.
+constexpr int IDC_VALUE_EDIT_BASE = 9100;
+
 constexpr int IDC_THEME_AUTO  = 340;
 constexpr int IDC_THEME_LIGHT = 341;
 constexpr int IDC_THEME_DARK  = 342;
@@ -219,7 +222,7 @@ static constexpr std::array<AnalogValueOption, 15> kAnalogValues{{
     {L"Second opacity", &AnalogClockStyle::second_opacity_pct, 10, 100, 10},
     {L"Tick opacity", &AnalogClockStyle::tick_opacity_pct, 10, 100, 10},
     {L"Face opacity", &AnalogClockStyle::face_opacity_pct, 0, 100, 10},
-    {L"Clock radius", &AnalogClockStyle::radius_pct, 50, 100, 5},
+    {L"Clock size", &AnalogClockStyle::radius_pct, 50, 500, 10},
 }};
 
 constexpr int ANALOG_COLOR_COUNT = static_cast<int>(kAnalogColors.size());
@@ -274,7 +277,27 @@ struct Params {
     int scroll_y = 0;       // current scroll offset in pixels
     RECT clock_combo_rc{};  // base pixel rect of the combobox (unscrolled)
     DialogBrushes brushes;
+    // Inline numeric edit over an analog value box. -1 means none active.
+    int editing_value_idx = -1;
+    HWND value_edit = nullptr;
+    WNDPROC orig_value_edit_proc = nullptr;
+    bool value_edit_cancelled = false;
 };
+
+// Split an analog value row into [-] [label: value] [+] sub-rects so the
+// click handler and painter agree on geometry.
+struct AnalogValueParts { RECT minus, middle, plus; };
+static AnalogValueParts split_value_rect(const RECT& r) {
+    int w = r.right - r.left;
+    int btn_w = w / 6;
+    if (btn_w < 14) btn_w = 14;
+    if (btn_w > 24) btn_w = 24;
+    AnalogValueParts parts;
+    parts.minus  = {r.left, r.top, r.left + btn_w, r.bottom};
+    parts.plus   = {r.right - btn_w, r.top, r.right, r.bottom};
+    parts.middle = {r.left + btn_w + 1, r.top, r.right - btn_w - 1, r.bottom};
+    return parts;
+}
 
 // ─── Scroll & visibility ──────────────────────────────────────────────────────
 
@@ -419,6 +442,7 @@ static void update_content_scroll(HWND dlg, Params* p) {
 
 // Apply scroll delta and reposition the combobox if on the clock tab.
 static void apply_scroll(HWND dlg, Params* p, int new_pos) {
+    close_value_edit(dlg, *p);
     SCROLLINFO si = {sizeof(SCROLLINFO), SIF_POS, 0, 0, 0, 0, 0};
     si.nPos = new_pos;
     SetScrollInfo(dlg, SB_VERT, &si, TRUE);
@@ -455,6 +479,8 @@ static bool read_field(HWND dlg, int id, int& out) {
 static Params* dialog_params(HWND dlg) {
     return reinterpret_cast<Params*>(GetWindowLongPtrW(dlg, DWLP_USER));
 }
+
+static void close_value_edit(HWND dlg, Params& p);
 
 static constexpr struct { ThemeMode mode; int id; } kThemeMap[] = {
     {ThemeMode::Auto,  IDC_THEME_AUTO},
@@ -507,6 +533,7 @@ static void apply_tab_visibility(HWND dlg, int active_tab) {
 }
 
 static void set_active_tab(HWND dlg, Params& p, int tab) {
+    close_value_edit(dlg, p);
     p.active_tab = tab;
     apply_tab_visibility(dlg, tab);
     update_content_scroll(dlg, &p);
@@ -696,7 +723,13 @@ static void paint_analog_settings(HWND dlg, HDC hdc, Params& p, int sdy) {
         int* field = analog_value_field(p.analog_style, i);
         wchar_t buf[96];
         wsprintfW(buf, L"%s: %d", kAnalogValues[(size_t)i].label, field ? *field : 0);
-        paint_option_btn(hdc, r, buf, false, s);
+        auto parts = split_value_rect(r);
+        paint_option_btn(hdc, parts.minus, L"−", false, s);
+        // While editing this row, the EDIT child paints the middle; skip it
+        // here so we don't flicker behind the live edit.
+        if (p.editing_value_idx != i)
+            paint_option_btn(hdc, parts.middle, buf, false, s);
+        paint_option_btn(hdc, parts.plus, L"+", false, s);
     }
 }
 
@@ -792,9 +825,88 @@ static INT_PTR on_draw_item(HWND dlg, LPARAM lp) {
     return TRUE;
 }
 
+static LRESULT CALLBACK value_edit_subclass(HWND edit, UINT msg, WPARAM wp, LPARAM lp) {
+    HWND parent = GetParent(edit);
+    auto* p = dialog_params(parent);
+    if (!p) return DefWindowProcW(edit, msg, wp, lp);
+    if (msg == WM_KEYDOWN) {
+        if (wp == VK_RETURN) {
+            SetFocus(parent);
+            return 0;
+        }
+        if (wp == VK_ESCAPE) {
+            p->value_edit_cancelled = true;
+            SetFocus(parent);
+            return 0;
+        }
+    }
+    return CallWindowProcW(p->orig_value_edit_proc, edit, msg, wp, lp);
+}
+
+static void start_value_edit(HWND dlg, Params& p, int i) {
+    if (p.editing_value_idx >= 0 || i < 0 || i >= ANALOG_VALUE_COUNT) return;
+    int* field = analog_value_field(p.analog_style, i);
+    if (!field) return;
+
+    RECT box = shifted(p.rects.analog_values[i], -p.scroll_y);
+    auto parts = split_value_rect(box);
+    RECT mid = parts.middle;
+
+    wchar_t buf[16];
+    wsprintfW(buf, L"%d", *field);
+    HWND edit = CreateWindowExW(
+        0, L"EDIT", buf,
+        WS_CHILD | WS_VISIBLE | WS_BORDER | ES_CENTER | ES_NUMBER | ES_AUTOHSCROLL,
+        mid.left, mid.top, mid.right - mid.left, mid.bottom - mid.top,
+        dlg, (HMENU)(INT_PTR)(IDC_VALUE_EDIT_BASE + i), nullptr, nullptr);
+    if (!edit) return;
+    SendMessageW(edit, EM_SETLIMITTEXT, 4, 0);
+    SendMessageW(edit, WM_SETFONT, (WPARAM)p.style.font, TRUE);
+    p.value_edit_cancelled = false;
+    p.orig_value_edit_proc = (WNDPROC)SetWindowLongPtrW(edit, GWLP_WNDPROC, (LONG_PTR)value_edit_subclass);
+    p.value_edit = edit;
+    p.editing_value_idx = i;
+    SetFocus(edit);
+    SendMessageW(edit, EM_SETSEL, 0, -1);
+    InvalidateRect(dlg, nullptr, TRUE);
+}
+
+// Commit/cancel the active inline edit by transferring focus, which fires
+// EN_KILLFOCUS. Caller handles the actual field update in that handler.
+static void close_value_edit(HWND dlg, Params& p) {
+    if (!p.value_edit) return;
+    SetFocus(dlg);
+}
+
+static bool handle_value_edit_killfocus(HWND dlg, int id, HWND edit, Params& p) {
+    if (id < IDC_VALUE_EDIT_BASE || id >= IDC_VALUE_EDIT_BASE + ANALOG_VALUE_COUNT) return false;
+    int i = id - IDC_VALUE_EDIT_BASE;
+    int* field = analog_value_field(p.analog_style, i);
+    const auto& opt = kAnalogValues[(size_t)i];
+    if (field && !p.value_edit_cancelled) {
+        wchar_t buf[16] = {};
+        GetWindowTextW(edit, buf, 15);
+        wchar_t* end = nullptr;
+        long v = std::wcstol(buf, &end, 10);
+        if (end && *end == L'\0' && buf[0] != L'\0')
+            *field = std::clamp((int)v, opt.min_value, opt.max_value);
+    }
+    p.value_edit_cancelled = false;
+    p.editing_value_idx = -1;
+    p.value_edit = nullptr;
+    p.orig_value_edit_proc = nullptr;
+    DestroyWindow(edit);
+    InvalidateRect(dlg, nullptr, TRUE);
+    return true;
+}
+
 static INT_PTR on_left_button_down(HWND dlg, LPARAM lp) {
     auto* p = dialog_params(dlg);
     if (!p) return FALSE;
+
+    // A click anywhere in the dialog body means the user is done with any
+    // inline edit; commit it before reacting to the new click.
+    close_value_edit(dlg, *p);
 
     POINT pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
 
@@ -832,9 +944,19 @@ static INT_PTR on_left_button_down(HWND dlg, LPARAM lp) {
             }
         }
         for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
-            if (PtInRect(&p->rects.analog_values[i], spt)) {
+            auto parts = split_value_rect(p->rects.analog_values[i]);
+            if (PtInRect(&parts.minus, spt)) {
+                adjust_analog_value(p->analog_style, i, -1);
+                InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
+            if (PtInRect(&parts.plus, spt)) {
                 adjust_analog_value(p->analog_style, i, 1);
                 InvalidateRect(dlg, nullptr, TRUE);
+                return TRUE;
+            }
+            if (PtInRect(&parts.middle, spt)) {
+                start_value_edit(dlg, *p, i);
                 return TRUE;
             }
         }
@@ -943,7 +1065,15 @@ static bool commit_all_tabs(HWND dlg, Params& p) {
     return true;
 }
 
-static INT_PTR on_command(HWND dlg, WPARAM wp) {
+static INT_PTR on_command(HWND dlg, WPARAM wp, LPARAM lp) {
+    int id = LOWORD(wp);
+    int code = HIWORD(wp);
+    if (id >= IDC_VALUE_EDIT_BASE && id < IDC_VALUE_EDIT_BASE + ANALOG_VALUE_COUNT &&
+        code == EN_KILLFOCUS) {
+        auto* p = dialog_params(dlg);
+        if (p) handle_value_edit_killfocus(dlg, id, (HWND)lp, *p);
+        return TRUE;
+    }
     switch (LOWORD(wp)) {
     case IDC_CLOCK_COMBO:
         if (HIWORD(wp) == CBN_SELCHANGE) {
@@ -985,12 +1115,17 @@ static INT_PTR on_command(HWND dlg, WPARAM wp) {
         if (HIWORD(wp) != BN_CLICKED) return FALSE;
         auto* p = dialog_params(dlg);
         if (!p) return FALSE;
+        close_value_edit(dlg, *p);
         if (!commit_all_tabs(dlg, *p)) return TRUE;
         EndDialog(dlg, IDOK);
         return TRUE;
     }
     case IDC_SET_CANCEL:
         if (HIWORD(wp) != BN_CLICKED) return FALSE;
+        if (auto* p = dialog_params(dlg)) {
+            p->value_edit_cancelled = true;
+            close_value_edit(dlg, *p);
+        }
         EndDialog(dlg, IDCANCEL);
         return TRUE;
     }
@@ -1000,6 +1135,7 @@ static INT_PTR on_command(HWND dlg, WPARAM wp) {
 static INT_PTR on_right_button_down(HWND dlg, LPARAM lp) {
     auto* p = dialog_params(dlg);
     if (!p) return FALSE;
+    close_value_edit(dlg, *p);
     if (p->active_tab != TAB_CLOCK || p->clock_view != ClockView::Analog) return FALSE;
 
     POINT spt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp) + p->scroll_y};
@@ -1015,7 +1151,8 @@ static INT_PTR on_right_button_down(HWND dlg, LPARAM lp) {
         }
     }
     for (int i = 0; i < ANALOG_VALUE_COUNT; ++i) {
-        if (PtInRect(&p->rects.analog_values[i], spt)) {
+        auto parts = split_value_rect(p->rects.analog_values[i]);
+        if (PtInRect(&parts.middle, spt)) {
             adjust_analog_value(p->analog_style, i, -1);
             InvalidateRect(dlg, nullptr, TRUE);
             return TRUE;
@@ -1052,7 +1189,7 @@ static INT_PTR CALLBACK DlgProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_RBUTTONDOWN:      return on_right_button_down(dlg, lp);
     case WM_VSCROLL:          return on_scroll(dlg, wp);
     case WM_MOUSEWHEEL:       return on_mouse_wheel(dlg, wp);
-    case WM_COMMAND:          return on_command(dlg, wp);
+    case WM_COMMAND:          return on_command(dlg, wp, lp);
     case WM_KEYDOWN:          return on_key_down(dlg, wp);
     }
     return FALSE;

--- a/src/win32/window.cpp
+++ b/src/win32/window.cpp
@@ -124,9 +124,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     }
     case WM_GETMINMAXINFO: {
         // Only enforce minimum width; height is handled by WM_WINDOWPOSCHANGING.
+        // Oversized analog clocks need the larger min_client_w too, otherwise
+        // the user could drag the window narrower and silently clip the clock.
         auto* m = (MINMAXINFO*)lp;
         DWORD ws = (DWORD)GetWindowLongW(hwnd, GWL_STYLE);
-        RECT adj{0, 0, s->layout.bar_min_client_w(), 0};
+        RECT adj{0, 0, min_client_w_for(*s), 0};
         AdjustWindowRectEx(&adj, ws, FALSE, 0);
         m->ptMinTrackSize.x = adj.right - adj.left;
         return 0;

--- a/tests/test_layout.cpp
+++ b/tests/test_layout.cpp
@@ -144,6 +144,34 @@ TEST_CASE("effective_clk_h returns correct height per view", "[layout]") {
     REQUIRE(effective_clk_h(l, ClockView::Analog) == 120);
 }
 
+TEST_CASE("effective_clk_h: analog radius below or at 100 keeps base height", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    REQUIRE(effective_clk_h(l, ClockView::Analog, 50) == 120);
+    REQUIRE(effective_clk_h(l, ClockView::Analog, 100) == 120);
+}
+
+TEST_CASE("effective_clk_h: analog radius above 100 scales height", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    REQUIRE(effective_clk_h(l, ClockView::Analog, 200) == 240);
+    REQUIRE(effective_clk_h(l, ClockView::Analog, 500) == 600);
+}
+
+TEST_CASE("effective_clk_h: radius_pct ignored for digital views", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    REQUIRE(effective_clk_h(l, ClockView::H24_HMS, 500) == 62);
+}
+
+TEST_CASE("client_height_for: oversized analog grows the layout", "[layout]") {
+    Layout l;
+    l.update_for_dpi(96);
+    LayoutState base{true, false, false, false, 1, 0, ClockView::Analog, 100};
+    LayoutState big{true, false, false, false, 1, 0, ClockView::Analog, 300};
+    REQUIRE(client_height_for(l, big) - client_height_for(l, base) == 240);
+}
+
 TEST_CASE("timer_index_at_y accounts for analog clock height", "[layout]") {
     Layout l;
     l.update_for_dpi(96);


### PR DESCRIPTION
## Summary
This PR adds inline numeric editing for analog clock style values (opacity, radius, etc.) in the settings dialog, along with support for scaling the analog clock display beyond 100% radius.

## Key Changes

- **Inline value editing**: Users can now click on analog value boxes to edit them directly with a numeric input field, with +/− buttons for incremental adjustments
  - Added `start_value_edit()` and `close_value_edit()` functions to manage the edit lifecycle
  - Added `value_edit_subclass()` window procedure to handle Enter/Escape keys in the edit control
  - Added `handle_value_edit_killfocus()` to commit or cancel edits when focus is lost

- **Analog value box layout**: Split each analog value row into three clickable regions (−, middle, +) using new `split_value_rect()` helper
  - Left button (−) decreases value
  - Middle area opens inline editor or can be right-clicked to decrease
  - Right button (+) increases value

- **Analog clock scaling**: Extended analog clock radius range from 50-100% to 50-500% with 10% increments
  - Updated `effective_clk_h()` to scale the analog clock drawing area linearly above 100%
  - Modified `LayoutState` to include `analog_radius_pct` field
  - Updated `resize_window()` to ensure window width accommodates oversized analog clocks
  - Added `min_client_w_for()` to calculate minimum width needed for scaled clocks

- **Settings dialog improvements**:
  - Close any active inline edit when scrolling, changing tabs, or clicking elsewhere
  - Cancel inline edit on dialog cancel
  - Updated label from "Clock radius" to "Clock size" for clarity

- **Tests**: Added comprehensive test cases for `effective_clk_h()` scaling behavior with various radius percentages

## Implementation Details

- Inline edits use a dynamically created EDIT control with ID `IDC_VALUE_EDIT_BASE + index`
- The edit control is subclassed to intercept Enter (commit) and Escape (cancel) keys
- Values are clamped to the configured min/max range on commit
- The painting code skips rendering the middle section while editing to avoid flicker
- Window resizing now considers analog clock size to prevent clipping oversized clocks

https://claude.ai/code/session_01Eq79ksosv2ZJG65UUSGTFc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analog clock size range expanded—now adjustable beyond 100%.
  * Settings dialog supports inline numeric editing for analog clock size with −/value/+ controls and direct value entry.

* **Bug Fixes**
  * Window and layout now resize correctly to prevent oversized analog clocks from being clipped.

* **Tests**
  * Added tests covering analog clock height and client-height behavior with radius scaling.

* **Documentation**
  * Clarified scaling behavior for analog clock rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->