### PR TITLE
ci: add Catch2 submodule and valgrind/clang-tidy/cppcheck analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install MSYS2 + toolchain
         uses: msys2/setup-msys2@v2
@@ -68,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         uses: ./.github/actions/setup-llvm
@@ -109,6 +113,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         uses: ./.github/actions/setup-llvm
@@ -150,6 +156,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         uses: ./.github/actions/setup-llvm
@@ -205,6 +213,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         uses: ./.github/actions/setup-llvm
@@ -241,3 +251,108 @@ jobs:
         uses: ./.github/actions/report-failure
         with:
           job-name: sanitizer-check
+
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-llvm
+
+      - name: Install Valgrind
+        run: sudo apt-get install -y valgrind
+
+      - name: Configure (debug, no sanitizers)
+        run: |
+          set -o pipefail
+          cmake --preset debug -DCMAKE_CXX_COMPILER=clang++-19 2>&1 | tee configure-output.txt
+
+      - name: Build
+        run: |
+          set -o pipefail
+          cmake --build build 2>&1 | tee build-output.txt
+
+      - name: Run tests under Valgrind
+        run: |
+          set -o pipefail
+          valgrind \
+            --error-exitcode=1 \
+            --leak-check=full \
+            --errors-for-leak-kinds=definite,indirect \
+            --quiet \
+            ./build/chronos_tests 2>&1 | tee valgrind-output.txt
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: valgrind-logs
+          retention-days: 7
+          path: |
+            configure-output.txt
+            build-output.txt
+            valgrind-output.txt
+          if-no-files-found: ignore
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-llvm
+
+      - name: Install clang-tidy
+        run: sudo apt-get install -y clang-tidy-19
+
+      - name: Configure (generate compile_commands.json)
+        run: |
+          cmake --preset debug -DCMAKE_CXX_COMPILER=clang++-19
+
+      - name: Run clang-tidy on core layer
+        run: |
+          set -o pipefail
+          find src/core -name '*.cpp' | \
+            xargs clang-tidy-19 -p build --warnings-as-errors='*' 2>&1 | tee clang-tidy-output.txt
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-logs
+          retention-days: 7
+          path: clang-tidy-output.txt
+          if-no-files-found: ignore
+
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck on core layer
+        run: |
+          set -o pipefail
+          cppcheck \
+            --error-exitcode=1 \
+            --enable=warning,performance,portability \
+            --suppress=missingIncludeSystem \
+            --std=c++23 \
+            -I src/core \
+            src/core 2>&1 | tee cppcheck-output.txt
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-logs
+          retention-days: 7
+          path: cppcheck-output.txt
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install MSYS2 + toolchain
@@ -71,6 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -114,6 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -157,6 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -214,6 +218,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -257,6 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -302,6 +308,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies
@@ -333,6 +340,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install cppcheck
         run: sudo apt-get install -y cppcheck

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/Catch2"]
+	path = third_party/Catch2
+	url = https://github.com/catchorg/Catch2.git

--- a/src/core/config_serial.cpp
+++ b/src/core/config_serial.cpp
@@ -276,8 +276,9 @@ bool config_read(Config& c, std::istream& f) {
     for (std::string line; std::getline(f, line);) {
         auto eq = line.find('=');
         if (eq == std::string::npos) continue;
-        std::string_view key{line.data(), eq};
-        std::string_view rest{line.data() + eq + 1, line.size() - eq - 1};
+        std::string_view sv{line};
+        std::string_view key = sv.substr(0, eq);
+        std::string_view rest = sv.substr(eq + 1);
 
         if (read_string_key(c, key, rest)) continue;
         long long val;


### PR DESCRIPTION
## Summary

- Add Catch2 v3.8.1 as a git submodule at `third_party/Catch2` (CMake already prefers the bundled copy via `CHRONOS_USE_BUNDLED_CATCH2`; all CI jobs updated to `submodules: recursive`)
- Add `valgrind` CI job: debug build (no sanitizers), runs full test suite under valgrind checking for definite/indirect memory leaks
- Add `clang-tidy` CI job: generates `compile_commands.json` then runs `clang-tidy-19` with `--warnings-as-errors` on `src/core/`
- Add `cppcheck` CI job: runs on `src/core/` with warning, performance, and portability checks enabled

`clang-tidy` and `cppcheck` are scoped to `src/core/` (the platform-independent layer) to avoid false positives from Win32/X11 headers unavailable on Linux CI.

## Test plan

- [ ] Valgrind job builds and runs `chronos_tests` under valgrind with no reported leaks
- [ ] clang-tidy job passes on `src/core/` sources
- [ ] cppcheck job passes on `src/core/` sources
- [ ] Existing CI jobs (test-linux, sanitizer-check, coverage, build-and-test) still pass with the submodule checkout

https://claude.ai/code/session_011zRqBwAaRCEM5nuwknSYgF

---
_Generated by [Claude Code](https://claude.ai/code/session_011zRqBwAaRCEM5nuwknSYgF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Catch2 testing framework as a repository submodule.
  * Updated CI checkout to fetch submodules recursively.

* **Tests / QA**
  * Added automated memory-leak checking and runtime diagnostics.
  * Added static analysis checks (clang-tidy and cppcheck) as CI jobs to improve code quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andreasnonslid/chronos/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->