### PR TITLE
fix(ui): drop alarm row striping that read as selection highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Alarm list no longer paints a striped/elevated background on every other row; newly added rows look identical to existing rows and no longer read as "highlighted" (#421)
+
 ## [1.20.1] — 2026-06-04
 
 ### Fixed

--- a/src/ui/ui_scene.hpp
+++ b/src/ui/ui_scene.hpp
@@ -493,9 +493,6 @@ inline void add_alarms(Scene& scene, const Layout& layout, int client_w, int& y,
     for (int i = 0; i < (int)state.alarms.size(); ++i) {
         const auto& alarm = state.alarms[i];
         int row_bottom = y + layout.alarm_row_h;
-        // Striped row background on every other entry.
-        if (i % 2 == 1)
-            add_fill(scene, {0, y, client_w, row_bottom}, ui.surface(SurfaceConfig{.elevated = true}));
 
         int row_mid = y + layout.alarm_row_h / 2;
         int del_x = client_w - pad - del_w;


### PR DESCRIPTION
Closes #421.

## Summary
`add_alarms` painted an elevated surface on every other row (`i % 2 == 1`). With an odd number of alarms, the last (most recently added) row got the stripe, which read as "highlighted/selected" rather than "stripe". Removed the stripe entirely — rows are short enough that striping isn't needed for scannability.

## Changes
- `src/ui/ui_scene.hpp`: drop the `i % 2 == 1` elevated-surface fill in `add_alarms`.
- `CHANGELOG.md`: `[Unreleased] → Fixed` entry.

## ⚠️ Release reminder
**On merge: cut a new patch release** (`1.20.2`) — update `CHANGELOG.md` with the dated header and tag.

## Test plan
- [ ] Open the app, enable Alarms.
- [ ] Add several alarms — confirm all rows have identical background.
- [ ] Confirm hover/click states still look right.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZXq57gkUKB3sf3CdKkfAS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed alarm list display by removing the striped background styling that was being incorrectly applied to alternate rows, including newly added alarms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->