### PR TITLE
test(alarm): cover firing predicate across days/date/boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `alarm_matches_wallclock()` pure predicate in `alarm.hpp` encapsulates "does this alarm fire at the given wall-clock instant?"; Win32 `check_alarms` now delegates to it instead of branching inline (#422)
+- 11 new `TEST_CASE`s in `tests/test_alarm.cpp` covering the firing predicate: days-mask matches, ALARM_ALL_DAYS / empty mask / weekday / weekend masks, midnight and 23:59 boundary minutes, date schedules ignoring days_mask, and disabled alarms (#422)
+
 ## [1.20.1] — 2026-06-04
 
 ### Fixed

--- a/src/core/alarm.hpp
+++ b/src/core/alarm.hpp
@@ -26,3 +26,16 @@ struct Alarm {
     bool enabled = true;
     bool notified = false;  // runtime-only, not persisted; reset each minute by check_alarms
 };
+
+// Pure predicate: does `a` fire at the given wall-clock instant?
+// `dow_bit_mon0` is day-of-week with Monday=0..Sunday=6 (matches our day_mask bit layout).
+// Ignores the `notified` flag — caller is responsible for de-duping within a minute.
+inline bool alarm_matches_wallclock(const Alarm& a,
+                                    int hour, int minute, int dow_bit_mon0,
+                                    int year, int month, int day) {
+    if (!a.enabled) return false;
+    if (a.hour != hour || a.minute != minute) return false;
+    if (a.schedule == AlarmSchedule::Days)
+        return (a.days_mask & (1 << dow_bit_mon0)) != 0;
+    return a.date_year == year && a.date_month == month && a.date_day == day;
+}

--- a/src/win32/polling.cpp
+++ b/src/win32/polling.cpp
@@ -91,19 +91,9 @@ void check_alarms(HWND hwnd, WndState& s) {
     int dow_bit = (dow_sys == 0) ? 6 : (dow_sys - 1); // Mon=0 ... Sun=6
 
     for (auto& a : app.alarms) {
-        if (!a.enabled) continue;
         if (a.notified) continue;
-        if (a.hour != st.wHour || a.minute != st.wMinute) continue;
-
-        bool matches = false;
-        if (a.schedule == AlarmSchedule::Days) {
-            matches = (a.days_mask & (1 << dow_bit)) != 0;
-        } else {
-            matches = (a.date_year  == st.wYear  &&
-                       a.date_month == st.wMonth &&
-                       a.date_day   == st.wDay);
-        }
-        if (!matches) continue;
+        if (!alarm_matches_wallclock(a, st.wHour, st.wMinute, dow_bit,
+                                     st.wYear, st.wMonth, st.wDay)) continue;
 
         a.notified = true;
         MessageBeep(MB_ICONASTERISK);

--- a/tests/test_alarm.cpp
+++ b/tests/test_alarm.cpp
@@ -344,3 +344,118 @@ TEST_CASE("actions-alarm: alarm dispatch actions do not request blink", "[action
     REQUIRE_FALSE(wants_blink(A_ALARM_DEL + i));
     REQUIRE_FALSE(wants_blink(A_ALARM_TOGGLE + i));
 }
+
+// ─── firing predicate: alarm_matches_wallclock ───────────────────────────────
+//
+// The predicate replaces the inline branching previously embedded in
+// check_alarms (Win32 polling), so the rules below also pin down what the
+// shipping app actually does at the minute boundary.
+
+TEST_CASE("alarm-fire: days-schedule fires only on matching minute and day",
+          "[alarm]") {
+    Alarm a = make_alarm_days("Wake", 7, 30, ALARM_DAY_MON | ALARM_DAY_WED);
+
+    // Monday (dow=0), 07:30 → fires
+    REQUIRE(alarm_matches_wallclock(a, 7, 30, 0, 2026, 6, 1));
+    // Same Monday, wrong minute → no fire
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 7, 31, 0, 2026, 6, 1));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 7, 29, 0, 2026, 6, 1));
+    // Same Monday, wrong hour → no fire
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 8, 30, 0, 2026, 6, 1));
+    // Wednesday (dow=2), 07:30 → fires
+    REQUIRE(alarm_matches_wallclock(a, 7, 30, 2, 2026, 6, 3));
+    // Tuesday (dow=1) → no fire (not in mask)
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 7, 30, 1, 2026, 6, 2));
+    // Sunday (dow=6) → no fire
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 7, 30, 6, 2026, 6, 7));
+}
+
+TEST_CASE("alarm-fire: days-schedule with ALARM_ALL_DAYS fires every weekday",
+          "[alarm]") {
+    Alarm a = make_alarm_days("Daily", 0, 0, ALARM_ALL_DAYS);
+    for (int dow = 0; dow < 7; ++dow)
+        REQUIRE(alarm_matches_wallclock(a, 0, 0, dow, 2026, 1, 1));
+}
+
+TEST_CASE("alarm-fire: days-schedule with empty mask never fires", "[alarm]") {
+    Alarm a = make_alarm_days("Dead", 12, 0, /*days_mask=*/0);
+    for (int dow = 0; dow < 7; ++dow)
+        REQUIRE_FALSE(alarm_matches_wallclock(a, 12, 0, dow, 2026, 1, 1));
+}
+
+TEST_CASE("alarm-fire: days-schedule at midnight (00:00) boundary", "[alarm]") {
+    Alarm a = make_alarm_days("Midnight", 0, 0, ALARM_DAY_MON);
+    REQUIRE(alarm_matches_wallclock(a, 0, 0, 0, 2026, 6, 1));
+    // One minute before / after → no fire
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 23, 59, 6, 2026, 5, 31)); // Sun (dow=6)
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 0, 1, 0, 2026, 6, 1));
+}
+
+TEST_CASE("alarm-fire: days-schedule at 23:59 boundary", "[alarm]") {
+    Alarm a = make_alarm_days("LateNight", 23, 59, ALARM_DAY_MON);
+    REQUIRE(alarm_matches_wallclock(a, 23, 59, 0, 2026, 6, 1));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 23, 58, 0, 2026, 6, 1));
+    // 24:00 isn't a real clock instant; next minute is 00:00 the next day,
+    // which is dow=1 here.
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 0, 0, 1, 2026, 6, 2));
+}
+
+TEST_CASE("alarm-fire: date-schedule fires only on the exact date", "[alarm]") {
+    Alarm a = make_alarm_date("Birthday", 2026, 7, 15, 9, 0);
+    // Exact date and time, dow irrelevant for date schedule
+    REQUIRE(alarm_matches_wallclock(a, 9, 0, 2, 2026, 7, 15));
+    REQUIRE(alarm_matches_wallclock(a, 9, 0, 5, 2026, 7, 15));
+    // Wrong day / month / year
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 9, 0, 2, 2026, 7, 14));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 9, 0, 2, 2026, 6, 15));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 9, 0, 2, 2027, 7, 15));
+    // Wrong time on the right day
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 8, 59, 2, 2026, 7, 15));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 9, 1, 2, 2026, 7, 15));
+}
+
+TEST_CASE("alarm-fire: date-schedule ignores days_mask", "[alarm]") {
+    // Sanity: a date-schedule alarm with a deliberately wrong days_mask still
+    // fires on the configured date.
+    Alarm a = make_alarm_date("Date", 2026, 7, 15, 9, 0);
+    a.days_mask = 0;
+    REQUIRE(alarm_matches_wallclock(a, 9, 0, 2, 2026, 7, 15));
+}
+
+TEST_CASE("alarm-fire: disabled alarm never fires regardless of match",
+          "[alarm]") {
+    Alarm days_off = make_alarm_days("Off", 7, 30, ALARM_ALL_DAYS, /*enabled=*/false);
+    REQUIRE_FALSE(alarm_matches_wallclock(days_off, 7, 30, 0, 2026, 6, 1));
+
+    Alarm date_off = make_alarm_date("Off2", 2026, 7, 15, 9, 0, /*enabled=*/false);
+    REQUIRE_FALSE(alarm_matches_wallclock(date_off, 9, 0, 2, 2026, 7, 15));
+}
+
+TEST_CASE("alarm-fire: day-of-week bit mapping covers all seven days", "[alarm]") {
+    // For each day-of-week, an alarm with only that day's bit set should match
+    // exactly that dow and no others.
+    auto dow = GENERATE(0, 1, 2, 3, 4, 5, 6);
+    Alarm a = make_alarm_days("Single", 12, 0, 1 << dow);
+    for (int d = 0; d < 7; ++d) {
+        if (d == dow)
+            REQUIRE(alarm_matches_wallclock(a, 12, 0, d, 2026, 6, 1));
+        else
+            REQUIRE_FALSE(alarm_matches_wallclock(a, 12, 0, d, 2026, 6, 1));
+    }
+}
+
+TEST_CASE("alarm-fire: ALARM_WEEKDAYS matches Mon–Fri only", "[alarm]") {
+    Alarm a = make_alarm_days("Workday", 8, 0, ALARM_WEEKDAYS);
+    for (int d = 0; d < 5; ++d)
+        REQUIRE(alarm_matches_wallclock(a, 8, 0, d, 2026, 6, 1));
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 8, 0, 5, 2026, 6, 1)); // Sat
+    REQUIRE_FALSE(alarm_matches_wallclock(a, 8, 0, 6, 2026, 6, 1)); // Sun
+}
+
+TEST_CASE("alarm-fire: ALARM_WEEKEND matches Sat–Sun only", "[alarm]") {
+    Alarm a = make_alarm_days("Weekend", 10, 0, ALARM_WEEKEND);
+    for (int d = 0; d < 5; ++d)
+        REQUIRE_FALSE(alarm_matches_wallclock(a, 10, 0, d, 2026, 6, 1));
+    REQUIRE(alarm_matches_wallclock(a, 10, 0, 5, 2026, 6, 1));
+    REQUIRE(alarm_matches_wallclock(a, 10, 0, 6, 2026, 6, 1));
+}


### PR DESCRIPTION
Closes #422.

## Summary
The alarm-firing rule lived inline inside `check_alarms()` (Win32-only `polling.cpp`), so the actual "should this alarm fire right now?" decision had no unit-test coverage — only config round-trip and dispatch entry points did.

This PR extracts `alarm_matches_wallclock()` as a pure predicate in `alarm.hpp`, makes `check_alarms()` call it, and adds tests for it.

## Changes
- `src/core/alarm.hpp`: add `alarm_matches_wallclock(const Alarm&, hour, minute, dow_bit_mon0, year, month, day) → bool`. Pure; ignores the runtime-only `notified` flag.
- `src/win32/polling.cpp`: `check_alarms` now delegates to the predicate. Behavior unchanged.
- `tests/test_alarm.cpp`: 11 new `TEST_CASE`s covering the predicate.
- `CHANGELOG.md`: `[Unreleased] → Added`.

## Coverage added
- Days-mask: matching minute & day, single-day mask, `ALARM_ALL_DAYS`, empty mask, `ALARM_WEEKDAYS`, `ALARM_WEEKEND`.
- Minute boundaries: 00:00 and 23:59 (plus the minute before/after).
- Date schedule: exact-date match, ignores `days_mask`, rejects wrong day/month/year.
- Disabled alarms never fire regardless of match.
- Day-of-week bit mapping (Mon=0 .. Sun=6) verified for all 7 days.

## ⚠️ Release reminder
**On merge: cut a new patch release** (`1.20.2`) — update `CHANGELOG.md` with the dated header and tag.

## Test plan
- [x] `tests/test_alarm.cpp` builds and runs locally — all 322 assertions pass (34 test cases).
- [ ] Windows build of `chronos` still compiles after `check_alarms` refactor (no behavior change expected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZXq57gkUKB3sf3CdKkfAS)_